### PR TITLE
fix: use public dockerhub as our image repository

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ DOCKER_BUILDKIT=1
 COMPOSE_DOCKER_CLI_BUILD=1
 
 #----------- Version --------------------------#
-PIPELINE_BACKEND_VERSION=0.0.1-dev
+PIPELINE_BACKEND_VERSION=0.0.2-dev
 MODEL_BACKEND_VERSION=2.0.4
 
 #----------- Hosts and Ports ------------------#

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ networks:
 services:
   pipeline_backend_migrate:
     container_name: pipeline-backend-migrate
-    image: europe-west2-docker.pkg.dev/prj-c-devops-artifacts-a306/pipeline/pipeline-backend:${PIPELINE_BACKEND_VERSION}
+    image: instill/pipeline-backend:${PIPELINE_BACKEND_VERSION}
     restart: on-failure
     volumes:
       - ./backends/pipeline-backend/config:/pipeline-backend/configs
@@ -24,7 +24,7 @@ services:
 
   pipeline_backend:
     container_name: pipeline-backend
-    image: europe-west2-docker.pkg.dev/prj-c-devops-artifacts-a306/pipeline/pipeline-backend:${PIPELINE_BACKEND_VERSION}
+    image: instill/pipeline-backend:${PIPELINE_BACKEND_VERSION}
     restart: unless-stopped
     volumes:
       - ./backends/pipeline-backend/config:/pipeline-backend/configs


### PR DESCRIPTION
Because

To use public image repository provided by `dockerhub`

This commit

1. Move internal docker image repository to dockerhub
2. Bump pipeline-backend
