### PR TITLE
docs: fix readme banner image and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,14 @@
 </h1>
 
 <h4 align="center">
-    <p>
-        <a href="https://www.instill.tech">Website</a> |
-        <a href="https://discord.gg/sevxWsqpGh">Community</a> |
-        <a href="https://blog.instill.tech">Blog</a>
-    <p>
+    <a href="https://www.instill.tech/?utm_source=github&utm_medium=banner&utm_campaign=visual_data_preparation_readme">Website</a> |
+    <a href="https://discord.gg/sevxWsqpGh">Community</a> |
+    <a href="https://blog.instill.tech/?utm_source=github&utm_medium=banner&utm_campaign=visual_data_preparation_readme">Blog</a>
 </h4>
 
 <h4 align="center">
     <p>
-        <a href="https://www.instill.tech/get-access"><strong>Get Early Access</strong></a>
+        <a href="https://www.instill.tech/get-access/?utm_source=github&utm_medium=banner&utm_campaign=visual_data_preparation_readme"><strong>Get Early Access</strong></a>
     <p>
 </h4>
 


### PR DESCRIPTION
Because

- the banner image link is broken
- we want to track the performance of links in the docs

This commit

- fix the banner image link
- add UTM parameters in the links