### PR TITLE
docs: add documentation skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,41 @@
 </h4>
 
 ---
+
+**Visual Data Preparation (VDP)** is an open-source tool to streamline the end-to-end visual data processing pipeline:
+
+- Ingest unstructured visual data from data sources such as data lakes or IoT devices;
+- Transform visual data to meaningful structured data representations by Vision AI models;
+- Load the structured data into data warehouses, applications or other destinations.
+
+The goal of VDP is to seamlessly bring Vision AI into modern data stack with a standardised framework. Check our blog post [Missing piece in modern data stack: visual data preparation](https://blog.instill.tech/visual-data-preparation/?utm_source=github&utm_medium=banner&utm_campaign=vdp_readme) on how the tool is proposed to streamline unstructured visual data processing across different stakeholders.
+
+### Table of contents <!-- omit in toc -->
+- [How VDP works](#how-vdp-works)
+- [Quick start](#quick-start)
+- [Community support](#community-support)
+- [Documentation](#documentation)
+  - [API reference](#api-reference)
+  - [Build docker](#build-docker)
+- [License](#license)
+
+## How VDP works
+
+## Quick start
+
+## Community support
+
+For general help using VDP, you can use one of these channels:
+
+- [GitHub](https://github.com/instill-ai/vdp) (bug reports, feature requests, project discussions and contributions)
+- [Discord](https://discord.gg/sevxWsqpGh) (live discussion with the community and the Instill AI Team)
+
+## Documentation
+
+### API reference
+
+### Build docker
+
+## License
+
+See the [LICENSE](https://github.com/instill-ai/vdp/blob/main/LICENSE) file for licensing information.


### PR DESCRIPTION
Because

- we add the doc structure as the foundation for iteration   

This commit

- add README documentation structure
