### PR TITLE
chore(vdp): disable console building in make-latest.yml

### DIFF
--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -2,11 +2,6 @@ name: Make Latest
 
 on:
   workflow_dispatch:
-    inputs:
-      disableConsoleBuild:
-        description: 'Disable console'
-        required: true
-        default: "true"
   pull_request:
   push:
     branches:
@@ -55,13 +50,8 @@ jobs:
           envFile: .env
 
       - name: Launch Instill VDP (latest)
-        run: |
-          if "${{ github.event.inputs.disableConsoleBuild }}"; then
-          make latest BUILD=true PROFILE=console EDITION=local-ce:test
-          else
-            make latest BUILD=true PROFILE=all EDITION=local-ce:test
-          fi
-
+        run: make latest PROFILE=exclude-console EDITION=local-ce:test
+        
       - name: List all docker containers
         run: |
           docker ps -a

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -10,3 +10,10 @@ services:
         SERVICE_NAME: ${PIPELINE_BACKEND_HOST}
         GOLANG_VERSION: ${GOLANG_VERSION}
         K6_VERSION: ${K6_VERSION}
+    profiles:
+      - all
+      - exclude-api-gateway
+      - exclude-mgmt
+      - exclude-console
+      - exclude-model
+      - exclude-controller-model

--- a/docker-compose.latest.yml
+++ b/docker-compose.latest.yml
@@ -5,31 +5,31 @@ services:
   pipeline_backend_migrate:
     profiles:
       - all
-      - api-gateway
-      - mgmt
-      - console
-      - model
-      - controller-model
+      - exclude-api-gateway
+      - exclude-mgmt
+      - exclude-console
+      - exclude-model
+      - exclude-controller-model
     image: ${PIPELINE_BACKEND_IMAGE}:latest
 
   pipeline_backend_init:
     profiles:
       - all
-      - api-gateway
-      - mgmt
-      - console
-      - model
-      - controller-model
+      - exclude-api-gateway
+      - exclude-mgmt
+      - exclude-console
+      - exclude-model
+      - exclude-controller-model
     image: ${PIPELINE_BACKEND_IMAGE}:latest
 
   pipeline_backend:
     profiles:
       - all
-      - api-gateway
-      - mgmt
-      - console
-      - model
-      - controller-model
+      - exclude-api-gateway
+      - exclude-mgmt
+      - exclude-console
+      - exclude-model
+      - exclude-controller-model
     image: ${PIPELINE_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -41,11 +41,11 @@ services:
   pipeline_backend_worker:
     profiles:
       - all
-      - api-gateway
-      - mgmt
-      - console
-      - model
-      - controller-model
+      - exclude-api-gateway
+      - exclude-mgmt
+      - exclude-console
+      - exclude-model
+      - exclude-controller-model
     image: ${PIPELINE_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"


### PR DESCRIPTION
Because

- We have to disable console building in make-latest.yml file due to consuming lot of time.

This commit

- Disable console building in make-latest.yml
