### PR TITLE
chore: add enabled flag to control the ray-cluster deployment

### DIFF
--- a/charts/core/templates/ray-service/monitor.yaml
+++ b/charts/core/templates/ray-service/monitor.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.rayService.enabled }}
 {{- if .Values.tags.prometheusStack }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -46,4 +47,5 @@ spec:
   # A list of endpoints allowed as part of this PodMonitor.
   podMetricsEndpoints:
   - port: metrics
+{{- end }}
 {{- end }}

--- a/charts/core/templates/ray-service/ray-service.yaml
+++ b/charts/core/templates/ray-service/ray-service.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.rayService.enabled }}
 {{- $modelRepository := .Values.persistence.persistentVolumeClaim.modelRepository -}}
 {{- $rayConda := .Values.persistence.persistentVolumeClaim.rayConda -}}
 apiVersion: ray.io/v1
@@ -212,3 +213,4 @@ data:
     serve start --http-host=0.0.0.0 --grpc-port 9000 --grpc-servicer-functions ray_pb2_grpc.add_RayServiceServicer_to_server
 
     echo "INFO: Start ray serve"
+{{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -676,6 +676,7 @@ kuberay-operator:
     - "instill-ai"
 # -- The configuration of Ray
 rayService:
+  enabled: true
   vram:
   spec:
     autoscalerOptions:


### PR DESCRIPTION
Because

- We need add the enabled flag for ray-services to `separate` the deployment of `ray-service` and `Instill-core`.

This commit

- add enabled flag to control the ray-cluster deployment
