### PR TITLE
chore(vdp): update pipeline db migration version

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -398,7 +398,7 @@ pipelineBackend:
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 11
+  dbVersion: 12
   # -- workflow setting
   workflow:
     maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- https://github.com/instill-ai/pipeline-backend/pull/410 introduced a new DB version

This commit

- Updates the DB version in the charts
