### PR TITLE
chore(helm): update chart

### DIFF
--- a/charts/core/templates/NOTES.txt
+++ b/charts/core/templates/NOTES.txt
@@ -3,3 +3,58 @@ You have installed/deployed:
   Chart name: {{ .Chart.Name }}
   Release name: {{ .Release.Name }}
   Fullname of k8s objects: {{ include "core.fullname" . }}
+
+Get the application URL by running these commands:
+{{- if eq .Values.expose.type "ingress" }}
+{{- range $key, $value := .Values.expose.ingress.hosts }}
+  http{{ if $.Values.internalTLS.enabled }}s{{ end }}://{{ $value }}
+{{- end }}
+{{- else if eq .Values.expose.type "nodePort" }}
+  export APIGATEWAY_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "core.apiGateway" . }})
+  export CONSOLE_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "core.console" . }})
+  {{- if .Values.tags.observability }}
+  export JAEGER_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services jaeger-query)
+  {{- end }}
+  {{- if .Values.tags.prometheusStack }}
+  export PROMETHEUS_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services prometheus)
+  export GRAFANA_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services grafana)
+  {{- end }}
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$APIGATEWAY_NODE_PORT
+  echo http://$NODE_IP:$CONSOLE_NODE_PORT
+{{- else if eq .Values.expose.type "loadBalancer" }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "core.apiGateway" . }}'
+export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "core.apiGateway" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if eq .Values.expose.type "clusterIP" }}
+  export API_GATEWAY_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export API_GATEWAY_CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $API_GATEWAY_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  export CONSOLE_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/component=console,app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONSOLE_CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $CONSOLE_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  {{- if .Values.tags.observability }}
+  export JAEGER_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/component=query,app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export JAEGER_CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $JAEGER_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  {{- end }}
+  {{- if .Values.tags.prometheusStack }}
+  export PROMETHEUS_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name=prometheus,app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export PROMETHEUS_CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $PROMETHEUS_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  export GRAFANA_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name=grafana,app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export GRAFANA_CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $GRAFANA_POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  {{- end }}
+  echo "Access to the api-gateway http://localhost:8080 and console http://localhost:3000 by:"
+  echo "kubectl --namespace {{ .Release.Namespace }} port-forward $API_GATEWAY_POD_NAME 8080:${API_GATEWAY_CONTAINER_PORT}"
+  echo "kubectl --namespace {{ .Release.Namespace }} port-forward $CONSOLE_POD_NAME 3000:${CONSOLE_CONTAINER_PORT}"
+  {{- if .Values.tags.observability }}
+  echo "Access to the observability stack"
+  echo "Jaeger UI at http://localhost:16686 by:"
+  echo "kubectl --namespace {{ .Release.Namespace }} port-forward $JAEGER_POD_NAME 16686:${JAEGER_CONTAINER_PORT}"
+  {{- end }}
+  {{- if .Values.tags.prometheusStack }}
+  echo "Access to the prometheus stack"
+  echo "Prometheus UI at http://localhost:9090 by:"
+  echo "kubectl --namespace {{ .Release.Namespace }} port-forward $PROMETHEUS_POD_NAME 9090:${PROMETHEUS_CONTAINER_PORT}"
+  echo "Grafana UI at http://localhost:3002 by:"
+  echo "kubectl --namespace {{ .Release.Namespace }} port-forward $GRAFANA_POD_NAME 3002:${GRAFANA_CONTAINER_PORT}"
+  {{- end }}
+{{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -398,7 +398,7 @@ pipelineBackend:
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 11
+  dbVersion: 12
   # -- workflow setting
   workflow:
     maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- the Helm chart needs to catch up the latest backend verison

This commit

- update the db version in `pipeline-backend`
- update `NOTES.txt` to better instruct the next steps after helm installation
