### PR TITLE
ci(workflows): specify repo checkout

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          repository: instill-ai/instill-core
 
       - name: Load .env file
         uses: cardinalby/export-env-action@v2
@@ -147,6 +149,8 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          repository: instill-ai/instill-core
 
       - name: Load .env file
         uses: cardinalby/export-env-action@v2

--- a/.github/workflows/helm-integration-test-console.yml
+++ b/.github/workflows/helm-integration-test-console.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          repository: instill-ai/instill-core
 
       - name: Load .env file
         uses: cardinalby/export-env-action@v2
@@ -152,10 +154,12 @@ jobs:
       - name: Start Minikube
         run: minikube start --cpus 4 --memory 10485
 
-      - name: Checkout repo (instill-core)
+      - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          repository: instill-ai/instill-core
 
-      - name: Load .env file (instill-core)
+      - name: Load .env file
         uses: cardinalby/export-env-action@v2
         with:
           envFile: .env

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          repository: instill-ai/instill-core
 
       - name: Load .env file
         uses: cardinalby/export-env-action@v2
@@ -93,6 +95,8 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          repository: instill-ai/instill-core
 
       - name: Load .env file
         uses: cardinalby/export-env-action@v2
@@ -144,6 +148,8 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          repository: instill-ai/instill-core
 
       - name: Load .env file
         uses: cardinalby/export-env-action@v2
@@ -202,6 +208,8 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          repository: instill-ai/instill-core
 
       - name: Load .env file
         uses: cardinalby/export-env-action@v2

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          repository: instill-ai/instill-core
 
       - name: Load .env file
         uses: cardinalby/export-env-action@v2
@@ -110,6 +112,8 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          repository: instill-ai/instill-core
 
       - name: Load .env file
         uses: cardinalby/export-env-action@v2

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -13,20 +13,6 @@ jobs:
           sudo kill -9 `sudo lsof -t -i:8084`
           sudo lsof -i -P -n | grep LISTEN
 
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/vdp
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Install k6
-        run: |
-          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
-
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
@@ -37,15 +23,19 @@ jobs:
       - name: Restart docker
         run: sudo service docker restart
 
-      - name: Checkout repo (core)
+      - name: Checkout repo
         uses: actions/checkout@v3
         with:
-          repository: instill-ai/
+          repository: instill-ai/instill-core
 
-      - name: Load .env file (core)
+      - name: Load .env file
         uses: cardinalby/export-env-action@v2
         with:
           envFile: .env
+
+      - name: Install k6
+        run: |
+          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
 
       - name: Launch Instill Core (release)
         run: |

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -17,20 +17,6 @@ jobs:
           sudo kill -9 `sudo lsof -t -i:8084`
           sudo lsof -i -P -n | grep LISTEN
 
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/vdp
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Install k6
-        run: |
-          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
-
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
@@ -43,11 +29,17 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          repository: instill-ai/instill-core
 
       - name: Load .env file
         uses: cardinalby/export-env-action@v2
         with:
           envFile: .env
+
+      - name: Install k6
+        run: |
+          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
 
       - name: Launch Instill Core (latest)
         run: |


### PR DESCRIPTION
Because

- when `workflow_call` from other repositories, the `actions/checkout` action by default checking out the caller repo, which is not what we want.

This commit

- specify the checked out repo to be always `instill-ai/instill-core`
