### PR TITLE
chore(helm): add pipeline and model backend as dependencies of api-gateway

### DIFF
--- a/charts/core/templates/api-gateway/deployment.yaml
+++ b/charts/core/templates/api-gateway/deployment.yaml
@@ -54,12 +54,22 @@ spec:
           args:
           - >
             while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${MGMT_BACKEND_HOST}:${MGMT_BACKEND_PORT}/v1beta/health/mgmt)" != "200" ]]; do echo waiting for mgmt-backend; sleep 1; done &&
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${PIPELINE_BACKEND_HOST}:${PIPELINE_BACKEND_PORT}/v1beta/health/pipeline)" != "200" ]]; do echo waiting for pipeline-backend; sleep 1; done &&
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${MODEL_BACKEND_HOST}:${MODEL_BACKEND_PORT}/v1alpha/health/model)" != "200" ]]; do echo waiting for model-backend; sleep 1; done &&
             while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${INFLUXDB_HOST}:${INFLUXDB_PORT}/health)" != "200" ]]; do echo waiting for influxdb; sleep 1; done
           env:
             - name: MGMT_BACKEND_HOST
               value: "{{ template "core.mgmtBackend" . }}"
             - name: MGMT_BACKEND_PORT
               value: "{{ template "core.mgmtBackend.publicPort" . }}"
+            - name: PIPELINE_BACKEND_HOST
+              value: "{{ template "core.pipelineBackend" . }}"
+            - name: PIPELINE_BACKEND_PORT
+              value: "{{ template "core.pipelineBackend.publicPort" . }}"
+            - name: MODEL_BACKEND_HOST
+              value: "{{ template "core.modelBackend" . }}"
+            - name: MODEL_BACKEND_PORT
+              value: "{{ template "core.modelBackend.publicPort" . }}"
             - name: INFLUXDB_HOST
               value: "{{ template "core.influxdb" . }}"
             - name: INFLUXDB_PORT


### PR DESCRIPTION
Because

- The api-gateway should start after the pipeline and model backend have started.

This commit

- Adds pipeline and model backend as dependencies of the api-gateway.