### PR TITLE
chore(helm): add enabled flag for registry service

### DIFF
--- a/charts/core/templates/registry/configmap.yaml
+++ b/charts/core/templates/registry/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.registry.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -26,3 +27,4 @@ data:
           timeout: 3s
           interval: 30s
           threshold: 3
+{{- end }}

--- a/charts/core/templates/registry/cronjob.yaml
+++ b/charts/core/templates/registry/cronjob.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.registry.enabled -}}
 {{- if .Values.registry.garbageCollect.enabled }}
 apiVersion: batch/v1
 kind: CronJob
@@ -67,4 +68,5 @@ spec:
             - name: config
               configMap:
                 name: {{ template "core.registry" . }}
+{{- end }}
 {{- end }}

--- a/charts/core/templates/registry/deployment.yaml
+++ b/charts/core/templates/registry/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.registry.enabled -}}
 {{- $registry := .Values.persistence.persistentVolumeClaim.registry -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -129,3 +130,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/core/templates/registry/hpa.yaml
+++ b/charts/core/templates/registry/hpa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.registry.enabled -}}
 {{- if .Values.registry.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -29,5 +30,6 @@ spec:
         target:
           type: AverageValue
           averageValue: {{ . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/core/templates/registry/service.yaml
+++ b/charts/core/templates/registry/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.registry.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,3 +21,4 @@ spec:
   selector:
     {{- include "core.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: registry
+{{- end -}}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1387,6 +1387,7 @@ openfga:
       maxUnavailable:
   # -- The configuration of registry
 registry:
+  enabled: false
   image:
     repository: registry
     tag: 2.8.3


### PR DESCRIPTION
Because

- Under some circumstances, `registry` may not need to be deployed

This commit

- add `enabled` flag for registry service
