### PR TITLE
chore(helm): support custom resource and cpu worker group

### DIFF
--- a/charts/core/templates/ray-service/ray-service.yaml
+++ b/charts/core/templates/ray-service/ray-service.yaml
@@ -68,7 +68,8 @@ spec:
                   path: storage.conf
         containers:
           - name: ray-head
-            image: {{ .Values.rayService.image.repository }}:{{ .Values.rayService.image.tag }}
+            # we need to have access to GPU for some reason in order to `podman run` gpu container in worker node
+            image: {{ .Values.rayService.image.repository }}:{{ .Values.rayService.image.tag }}-gpu
             securityContext:
               # for mounting /dev/fuse
               # TODO: maybe implement a fuse-device-plugin-daemonset
@@ -130,8 +131,11 @@ spec:
       maxReplicas: {{ $workerGroupSpecs.maxReplicas }}
       groupName: {{ $workerGroupSpecs.groupName }}
       rayStartParams:
+        {{- if $workerGroupSpecs.gpuWorkerGroup.customResource }}
+        resources: {{ $workerGroupSpecs.gpuWorkerGroup.customResource }}
+        {{- end }}
         disable-usage-stats: "true"
-      #pod template
+      # pod template
       template:
         spec:
           {{- with $workerGroupSpecs.nodeSelector }}
@@ -171,7 +175,7 @@ spec:
                     path: policy.json
           containers:
             - name: ray-worker
-              image: {{ $.Values.rayService.image.repository }}:{{ $.Values.rayService.image.tag }}
+              image: {{ $.Values.rayService.image.repository }}:{{ $.Values.rayService.image.tag }}{{ ternary "-gpu" "" $workerGroupSpecs.gpuWorkerGroup.enabled }}
               securityContext:
                 # for newuidmap
                 privileged: true

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -700,11 +700,13 @@ rayService:
   headGroupSpec:
     resources:
       limits:
-        cpu: "2"
+        cpu: "0"
         memory: "4Gi"
+        nvidia.com/gpu: 0
       requests:
-        cpu: "2"
+        cpu: "0"
         memory: "4Gi"
+        nvidia.com/gpu: 0
     affinity: {}
     nodeSelector: {}
   workerGroupSpecs:
@@ -714,6 +716,8 @@ rayService:
       groupName: "cpu-group"
       gpuWorkerGroup:
         enabled: false
+        # https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml#L39
+        customResource: # "'\"{\\\"3060\\\": 1}\"'"
         resources:
           limits:
             cpu: "2"


### PR DESCRIPTION
Because

- We need custom resource label to allow model to be deployed on desired gpu hardware
- We need to support pure CPU worker group

This commit

- use non GPU image for CPU worker group
- support custom resource label for different GPU type in ray worker groups
