### PR TITLE
chore(helm): add flag to disable model related services

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -21,10 +21,14 @@ dependencies:
   - name: kuberay-operator
     repository: https://ray-project.github.io/kuberay-helm/
     version: 1.0.0
+    tags:
+      - model
   - name: etcd
     repository: https://charts.bitnami.com/bitnami
     version: 8.8.1
     condition: etcd.enabled
+    tags:
+      - model
   - name: elasticsearch
     repository: https://helm.elastic.co
     version: 7.17.3

--- a/charts/core/templates/controller-model/configmap.yaml
+++ b/charts/core/templates/controller-model/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tags.model -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -46,3 +47,4 @@ data:
         cert: /etc/instill-ai/model/ssl/mgmt/tls.crt
         key: /etc/instill-ai/model/ssl/mgmt/tls.key
       {{- end }}
+{{- end }}

--- a/charts/core/templates/controller-model/deployment.yaml
+++ b/charts/core/templates/controller-model/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tags.model -}}
 {{- $modelRepository := .Values.persistence.persistentVolumeClaim.modelRepository -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -146,3 +147,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/core/templates/controller-model/hpa.yml
+++ b/charts/core/templates/controller-model/hpa.yml
@@ -1,3 +1,4 @@
+{{- if .Values.tags.model -}}
 {{- if .Values.controllerModel.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -29,5 +30,6 @@ spec:
         target:
           type: AverageValue
           averageValue: {{ . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/core/templates/controller-model/service.yaml
+++ b/charts/core/templates/controller-model/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tags.model -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,4 @@ spec:
   selector:
     {{- include "core.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller-model
+{{- end }}

--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tags.model -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -98,3 +99,4 @@ data:
     registry:
       host: {{ template "core.registry" . }}
       port: {{ template "core.registry.port" . }}
+{{- end }}

--- a/charts/core/templates/model-backend/deployment.yaml
+++ b/charts/core/templates/model-backend/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tags.model -}}
 {{- $modelRepository := .Values.persistence.persistentVolumeClaim.modelRepository -}}
 {{- $rayConda := .Values.persistence.persistentVolumeClaim.rayConda -}}
 apiVersion: apps/v1
@@ -248,3 +249,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/core/templates/model-backend/hpa.yml
+++ b/charts/core/templates/model-backend/hpa.yml
@@ -1,3 +1,4 @@
+{{- if .Values.tags.model -}}
 {{- if .Values.modelBackend.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -29,5 +30,6 @@ spec:
         target:
           type: AverageValue
           averageValue: {{ . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/core/templates/model-backend/post-install-job.yaml
+++ b/charts/core/templates/model-backend/post-install-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tags.model -}}
 {{- $modelRepository := .Values.persistence.persistentVolumeClaim.modelRepository -}}
 {{- if .Values.modelBackend.initModel.enabled -}}
 apiVersion: batch/v1
@@ -88,4 +89,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/core/templates/model-backend/service.yaml
+++ b/charts/core/templates/model-backend/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tags.model -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,3 +21,4 @@ spec:
   selector:
     {{- include "core.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: model-backend
+{{- end }}

--- a/charts/core/templates/ray-service/monitor.yaml
+++ b/charts/core/templates/ray-service/monitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tags.model -}}
 {{- if .Values.tags.prometheusStack }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -46,4 +47,5 @@ spec:
   # A list of endpoints allowed as part of this PodMonitor.
   podMetricsEndpoints:
   - port: metrics
+{{- end }}
 {{- end }}

--- a/charts/core/templates/ray-service/ray-service.yaml
+++ b/charts/core/templates/ray-service/ray-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tags.model -}}
 {{- $modelRepository := .Values.persistence.persistentVolumeClaim.modelRepository -}}
 {{- $rayConda := .Values.persistence.persistentVolumeClaim.rayConda -}}
 apiVersion: ray.io/v1
@@ -300,3 +301,4 @@ data:
   storage.conf: |
     [storage]
     driver = "overlay"
+{{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1482,5 +1482,6 @@ registry:
       tls:
         enabled: false
 tags:
+  model: true
   observability: true
   prometheusStack: false


### PR DESCRIPTION
Because

- Allow deploying `Instill Core` without `Model` related services

This commit

- add flag to disable model related services
