### PR TITLE
feat(helm): add configuration for read-replica database

### DIFF
--- a/charts/core/templates/mgmt-backend/configmap.yaml
+++ b/charts/core/templates/mgmt-backend/configmap.yaml
@@ -32,6 +32,13 @@ data:
       password: {{ default (include "core.database.rawPassword" .) .Values.database.external.password }}
       host: {{ default (include "core.database.host" .) .Values.database.external.host }}
       port: {{ default (include "core.database.port" .) .Values.database.external.port }}
+      {{- if .Values.database.external_replica }}
+      replica:
+        username: {{ .Values.database.external_replica.username | default "" }}
+        password: {{ .Values.database.external_replica.password | default ""  }}
+        host: {{ .Values.database.external_replica.host | default ""  }}
+        port: {{ .Values.database.external_replica.port | default ""  }}
+      {{- end }}
       name: mgmt
       version: {{ .Values.mgmtBackend.dbVersion }}
       timezone: Etc/UTC

--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -61,6 +61,13 @@ data:
       password: {{ default (include "core.database.rawPassword" .) .Values.database.external.password }}
       host: {{ default (include "core.database.host" .) .Values.database.external.host }}
       port: {{ default (include "core.database.port" .) .Values.database.external.port }}
+      {{- if .Values.database.external_replica }}
+      replica:
+        username: {{ .Values.database.external_replica.username | default "" }}
+        password: {{ .Values.database.external_replica.password | default ""  }}
+        host: {{ .Values.database.external_replica.host | default ""  }}
+        port: {{ .Values.database.external_replica.port | default ""  }}
+      {{- end }}
       name: model
       version: {{ .Values.modelBackend.dbVersion }}
       timezone: Etc/UTC

--- a/charts/core/templates/pipeline-backend/configmap.yaml
+++ b/charts/core/templates/pipeline-backend/configmap.yaml
@@ -55,6 +55,13 @@ data:
       password: {{ default (include "core.database.rawPassword" .) .Values.database.external.password }}
       host: {{ default (include "core.database.host" .) .Values.database.external.host }}
       port: {{ default (include "core.database.port" .) .Values.database.external.port }}
+      {{- if .Values.database.external_replica }}
+      replica:
+        username: {{ .Values.database.external_replica.username | default "" }}
+        password: {{ .Values.database.external_replica.password | default ""  }}
+        host: {{ .Values.database.external_replica.host | default ""  }}
+        port: {{ .Values.database.external_replica.port | default ""  }}
+      {{- end }}
       name: pipeline
       version: {{ .Values.pipelineBackend.dbVersion }}
       timezone: Etc/UTC

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1079,6 +1079,11 @@ database:
     port:
     username:
     password:
+  external_replica:
+    host:
+    port:
+    username:
+    password:
 # -- The configuration of etcd
 etcd:
   persistence:


### PR DESCRIPTION
Because

- We are going to support a read-replica database to improve query throughput.

This commit

- Adds configuration for the read-replica database.