### PR TITLE
chore(helm): fix model tag pvc scope and support gcs registry storage

### DIFF
--- a/charts/core/templates/pvc.yaml
+++ b/charts/core/templates/pvc.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.persistence.enabled }}
+{{- if .Values.tags.model -}}
 {{- $modelRepository := .Values.persistence.persistentVolumeClaim.modelRepository -}}
 {{- if not $modelRepository.existingClaim }}
 kind: PersistentVolumeClaim
@@ -57,6 +58,8 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+{{- end }}
+{{- if eq .Values.registry.config.storage.type "filesystem" }}
 {{- $registry := .Values.persistence.persistentVolumeClaim.registry -}}
 {{- if not $registry.existingClaim }}
 ---
@@ -87,6 +90,7 @@ spec:
   storageClassName: {{ $registry.storageClass }}
     {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- $database := .Values.persistence.persistentVolumeClaim.database -}}
 {{- if and (not $database.existingClaim) .Values.database.enabled }}

--- a/charts/core/templates/registry/configmap.yaml
+++ b/charts/core/templates/registry/configmap.yaml
@@ -12,7 +12,13 @@ data:
     log:
       {{- toYaml .Values.registry.config.log | nindent 6 }}
     storage:
-      {{- toYaml .Values.registry.config.storage | nindent 6 }}
+      {{- if eq .Values.registry.config.storage.type "gcs" }}
+      gcs:
+        {{- toYaml .Values.registry.config.storage.gcs | nindent 8 }}
+      {{- else }}
+      filesystem:
+        {{- toYaml .Values.registry.config.storage.filesystem | nindent 8 }}
+      {{- end }}
     http:
       {{- toYaml .Values.registry.config.http | nindent 6 }}
     redis:

--- a/charts/core/templates/registry/deployment.yaml
+++ b/charts/core/templates/registry/deployment.yaml
@@ -95,8 +95,10 @@ spec:
             - name: config
               mountPath: {{ .Values.registry.configPath }}
               subPath: config.yaml
+            {{- if eq .Values.registry.config.storage.type "filesystem" }}
             - name: data-volume
               mountPath: /var/lib/registry
+            {{- end }}
           {{- with .Values.registry.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -105,6 +107,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "core.registry" . }}
+        {{- if eq .Values.registry.config.storage.type "filesystem" }}
         - name: data-volume
         {{- if not .Values.persistence.enabled }}
           emptyDir: {}
@@ -114,6 +117,7 @@ spec:
         {{- else }}
           persistentVolumeClaim:
             claimName: {{ template "core.registryDataVolume" . }}
+        {{- end }}
         {{- end }}
         {{- with .Values.registry.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1435,9 +1435,25 @@ registry:
         service: registry
         environment: k8s:ce
     storage:
+      type: filesystem
       filesystem:
         rootdirectory: /var/lib/registry
         maxthreads: 100
+      gcs:
+        bucket:
+        keyfile:
+        credentials:
+          type:
+          project_id:
+          private_key_id:
+          private_key:
+          client_email:
+          client_id:
+          auth_uri:
+          token_uri:
+          auth_provider_x509_cert_url:
+          client_x509_cert_url:
+        rootdirectory:
       delete:
         enabled: true
       redirect:


### PR DESCRIPTION
Because

- `Model` service PVC not disabled by the `model` tag
- Support GCS storage backend for `registry` service

This commit

- fix `model` tag not disabling model pvc
- add support for GCS storage backend for `registry`
