### PR TITLE
feat(model): support new models

### DIFF
--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -30,26 +30,6 @@
     }
   },
   {
-    "id": "llama2-7b",
-    "description": "Llama2-7b, from meta, is trained to generate text based on your prompts.",
-    "task": "TASK_TEXT_GENERATION",
-    "model_definition": "model-definitions/github",
-    "configuration": {
-      "repository": "instill-ai/model-llama2-7b-dvc",
-      "tag": "f32-cpu-transformer-ray-v0.8.0"
-    }
-  },
-  {
-    "id": "llama2-7b-chat",
-    "description": "Llama2-7b-Chat, from meta, is trained to generate text based on your prompts.",
-    "task": "TASK_TEXT_GENERATION_CHAT",
-    "model_definition": "model-definitions/github",
-    "configuration": {
-      "repository": "instill-ai/model-llama2-7b-chat-dvc",
-      "tag": "f16-gpuAuto-transformer-ray-v0.8.0"
-    }
-  },
-  {
     "id": "llava-1-6-13b",
     "description": "LLaVa-13b, from liuhaotian, is trained to generate text based on your prompts with miltimodal input.",
     "task": "TASK_VISUAL_QUESTION_ANSWERING",
@@ -57,16 +37,6 @@
     "configuration": {
       "repository": "instill-ai/model-llava-13b-dvc",
       "tag": "f16-gpuAuto-transformer-ray-v0.11.0"
-    }
-  },
-  {
-    "id": "zephyr-7b",
-    "description": "Zephyr-7b, from Huggingface, is trained to generate text based on your prompts.",
-    "task": "TASK_TEXT_GENERATION_CHAT",
-    "model_definition": "model-definitions/github",
-    "configuration": {
-      "repository": "instill-ai/model-zephyr-7b-dvc",
-      "tag": "f32-cpu-transformer-ray-v0.8.0"
     }
   },
   {
@@ -87,6 +57,46 @@
     "configuration": {
       "repository": "instill-ai/model-controlnet-dvc",
       "tag": "f16-gpuAuto-diffusers-ray-v0.8.0"
+    }
+  },
+  {
+    "id": "llama2-7b",
+    "description": "Llama2-7b, from meta, is trained to generate text based on your prompts.",
+    "task": "TASK_TEXT_GENERATION",
+    "model_definition": "model-definitions/github",
+    "configuration": {
+      "repository": "instill-ai/model-llama2-7b-dvc",
+      "tag": "f32-cpu-transformer-ray-v0.8.0"
+    }
+  },
+  {
+    "id": "llama2-7b-chat",
+    "description": "Llama2-7b-Chat, from meta, is trained to generate text based on your prompts.",
+    "task": "TASK_TEXT_GENERATION_CHAT",
+    "model_definition": "model-definitions/github",
+    "configuration": {
+      "repository": "instill-ai/model-llama2-7b-chat-dvc",
+      "tag": "f16-gpuAuto-transformer-ray-v0.8.0"
+    }
+  },
+  {
+    "id": "zephyr-7b",
+    "description": "Zephyr-7b, from Huggingface, is trained to generate text based on your prompts.",
+    "task": "TASK_TEXT_GENERATION_CHAT",
+    "model_definition": "model-definitions/github",
+    "configuration": {
+      "repository": "instill-ai/model-zephyr-7b-dvc",
+      "tag": "f16-1gpu-transformer-ray-v0.11.0"
+    }
+  },
+  {
+    "id": "llamacode-7b",
+    "description": "Llamacode-7b, from Huggingface, is trained to generate text based on your prompts.",
+    "task": "TASK_TEXT_GENERATION_CHAT",
+    "model_definition": "model-definitions/github",
+    "configuration": {
+      "repository": "instill-ai/model-codellama-7b-dvc",
+      "tag": "f16-1gpu-transformer-ray-v0.11.0"
     }
   }
 ]


### PR DESCRIPTION
Because

- in model-backend 0.12.0, we are going to utilize 4 A100 40G GPU 

This commit

- update model config based on the following strategy

GPU1:
yolov7
mobilenetv2
yolov7-stomata
llava 13b (needs 26G VRAM)

GPU 2:
stable-diffusion-xl  (needs 16G VRAM)
controlnet-canny  (needs 16G VRAM)

GPU 3:
llama2-7b  (needs 16G VRAM)
llama2-7b-chat  (needs 16G VRAM)

GPU 4:
llamacode 7b   (needs 16G VRAM)
zephyr-7b    (needs 16G VRAM)

