### PR TITLE
chore(helm): add configuration for OpenFGA read replica

### DIFF
--- a/charts/core/templates/mgmt-backend/configmap.yaml
+++ b/charts/core/templates/mgmt-backend/configmap.yaml
@@ -67,6 +67,11 @@ data:
     openfga:
       host: {{ template "core.openfga" . }}
       port: 8080
+      {{- if .Values.database.external_replica }}
+      replica:
+        host: {{ template "core.openfga" . }}
+        port: 8082
+      {{- end }}
     temporal:
       hostport: {{ default (printf "%s-frontend-headless:%s" (include "core.temporal" .) (include "core.temporal.frontend.grpcPort" .)) .Values.mgmtBackend.temporal.hostPort }}
       namespace: {{ default "mgmt-backend" .Values.mgmtBackend.temporal.namespace }}

--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -103,6 +103,11 @@ data:
     openfga:
       host: {{ template "core.openfga" . }}
       port: 8080
+      {{- if .Values.database.external_replica }}
+      replica:
+        host: {{ template "core.openfga" . }}
+        port: 8082
+      {{- end }}
     registry:
       host: {{ template "core.registry" . }}
       port: {{ template "core.registry.port" . }}

--- a/charts/core/templates/openfga/deployment.yaml
+++ b/charts/core/templates/openfga/deployment.yaml
@@ -100,6 +100,12 @@ spec:
           imagePullPolicy: {{ .Values.openfga.image.pullPolicy }}
           args: ['run']
           env:
+            - name: OPENFGA_PLAYGROUND_ENABLED
+              value: "false"
+            - name: OPENFGA_METRICS_ENABLED
+              value: "false"
+            - name: OPENFGA_DATASTORE_METRICS_ENABLED
+              value: "false"
             - name: OPENFGA_DATASTORE_ENGINE
               value: postgres
             - name: PGDATABASE
@@ -115,6 +121,38 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
+        {{- if .Values.database.external_replica }}
+        - name: openfga-read-replica
+          image: {{ .Values.openfga.image.repository }}:{{ .Values.openfga.image.tag }}
+          imagePullPolicy: {{ .Values.openfga.image.pullPolicy }}
+          args: ['run']
+          env:
+            - name: OPENFGA_HTTP_ADDR
+              value: 0.0.0.0:8082
+            - name: OPENFGA_GRPC_ADDR
+              value: 0.0.0.0:8083
+            - name: OPENFGA_PLAYGROUND_ENABLED
+              value: "false"
+            - name: OPENFGA_METRICS_ENABLED
+              value: "false"
+            - name: OPENFGA_DATASTORE_METRICS_ENABLED
+              value: "false"
+            - name: OPENFGA_DATASTORE_ENGINE
+              value: postgres
+            - name: PGDATABASE
+              value: openfga
+            - name: PGHOST
+              value: "{{ default (include "core.database.host" .) .Values.database.external_replica.host }}"
+            - name: PGPORT
+              value: "{{ default (include "core.database.port" .) .Values.database.external_replica.port }}"
+            - name: PGUSER
+              value: "{{ default (include "core.database.username" .) .Values.database.external_replica.username }}"
+            - name: PGPASSWORD
+              value: "{{ default (include "core.database.rawPassword" .) .Values.database.external_replica.password }}"
+          ports:
+            - containerPort: 8082
+              protocol: TCP
+          {{- end }}
       {{- with .Values.openfga.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/core/templates/openfga/service.yaml
+++ b/charts/core/templates/openfga/service.yaml
@@ -14,6 +14,11 @@ spec:
     - name: openfga
       port: 8080
       targetPort: 8080
+    {{- if .Values.database.external_replica }}
+    - name: openfga-read-replica
+      port: 8082
+      targetPort: 8082
+    {{- end }}
   selector:
     {{- include "core.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: openfga

--- a/charts/core/templates/pipeline-backend/configmap.yaml
+++ b/charts/core/templates/pipeline-backend/configmap.yaml
@@ -97,3 +97,8 @@ data:
     openfga:
       host: {{ template "core.openfga" . }}
       port: 8080
+      {{- if .Values.database.external_replica }}
+      replica:
+        host: {{ template "core.openfga" . }}
+        port: 8082
+      {{- end }}


### PR DESCRIPTION
Because

- In the multi-region deployment, we will separate the read/write operations into different databases and OpenFGA engines.

This commit

- Adds connection settings for OpenFGA read replica.