### PR TITLE
chore(model): update llama2 model to gpu

### DIFF
--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -66,7 +66,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llama2-7b-dvc",
-      "tag": "f32-cpu-transformer-ray-v0.8.0"
+      "tag": "f16-gpu-transformer-ray-v0.8.0"
     }
   },
   {


### PR DESCRIPTION
Because

- in model-backend 0.23.0, we are going to utilize 4 A100 40G GPU 

This commit

- update model config based on the following strategy

GPU1:
yolov7
mobilenetv2
yolov7-stomata
llava 13b (needs 26G VRAM)

GPU 2:
stable-diffusion-xl  (needs 16G VRAM)
controlnet-canny  (needs 16G VRAM)

GPU 3:
llama2-7b  (needs 16G VRAM)
llama2-7b-chat  (needs 16G VRAM)

GPU 4:
llamacode 7b   (needs 16G VRAM)
zephyr-7b    (needs 16G VRAM)

