### PR TITLE
chore(helm): add configuration to override model-backend host

### DIFF
--- a/charts/core/templates/pipeline-backend/configmap.yaml
+++ b/charts/core/templates/pipeline-backend/configmap.yaml
@@ -43,8 +43,8 @@ data:
         key: /etc/instill-ai/vdp/ssl/mgmt/tls.key
       {{- end }}
     modelbackend:
-      host: {{ template "core.modelBackend" . }}
-      publicport: {{ template "core.modelBackend.publicPort" . }}
+      host: {{ default (include "core.modelBackend" . ) .Values.pipelineBackend.modelBackendHostOverride }}
+      publicport: {{ default (include "core.modelBackend.publicPort" . ) .Values.pipelineBackend.modelBackendPortOverride }}
       {{- if .Values.internalTLS.enabled }}
       https:
         cert: /etc/instill-ai/vdp/ssl/model/tls.crt

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -472,6 +472,8 @@ pipelineBackend:
       minAvailable:
       maxUnavailable:
   copyHostDocker: false
+  modelBackendHostOverride:
+  modelBackendPortOverride:
 # -- The configuration of model-backend
 modelBackend:
   # -- The image of model-backend


### PR DESCRIPTION
Because

- In the multi-region architecture, the Instill Model connector needs to connect to the model-backend through an external network instead of an internal network, we need to have a configuration for this.

This commit:

- Adds configuration to override the model-backend host.