### PR TITLE
fix(cicd): fix uploading console tests artifact issue

### DIFF
--- a/.github/workflows/helm-integration-test-console.yml
+++ b/.github/workflows/helm-integration-test-console.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           git clone https://github.com/instill-ai/console.git
           cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:latest .
-          docker run -t --rm \
+          docker run -t \
             -e NEXT_PUBLIC_GENERAL_API_VERSION=v1beta \
             -e NEXT_PUBLIC_MODEL_API_VERSION=v1alpha \
             -e NEXT_PUBLIC_CONSOLE_EDITION=k8s-ce:test \
@@ -124,6 +124,11 @@ jobs:
           name: helm-integration-test-latest-linux-test-results
           path: test-results
           retention-days: 1
+
+      - name: Stop and remove console playwright
+        run: |
+          docker stop console-integration-test
+          docker rm console-integration-test
 
   helm-integration-test-latest-mac:
     if: false
@@ -230,7 +235,7 @@ jobs:
         run: |
           git clone -b v$CONSOLE_VERSION https://github.com/instill-ai/console.git
           cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:${{ env.CONSOLE_VERSION }} .
-          docker run -t --rm \
+          docker run -t \
             -e NEXT_PUBLIC_GENERAL_API_VERSION=v1beta \
             -e NEXT_PUBLIC_MODEL_API_VERSION=v1alpha \
             -e NEXT_PUBLIC_CONSOLE_EDITION=k8s-ce:test \
@@ -255,6 +260,11 @@ jobs:
           name: helm-integration-test-release-linux-test-results
           path: test-results
           retention-days: 1
+
+      - name: Stop and remove console playwright
+        run: |
+          docker stop console-integration-test
+          docker rm console-integration-test
 
   helm-integration-test-release-mac:
     if: false

--- a/.github/workflows/helm-integration-test-console.yml
+++ b/.github/workflows/helm-integration-test-console.yml
@@ -113,6 +113,18 @@ jobs:
             --name core-console-integration-test-latest \
             console-playwright:latest
 
+      - name: Copy the test-result to host
+        if: always()
+        run: docker cp core-console-integration-test-latest:/app/apps/console/test-results ./test-results
+
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: helm-integration-test-latest-linux-test-results
+          path: test-results
+          retention-days: 1
+
   helm-integration-test-latest-mac:
     if: false
     # disable the mac test temporary
@@ -231,6 +243,18 @@ jobs:
             --entrypoint ./entrypoint-playwright.sh \
             --name core-console-integration-test-release \
             console-playwright:${{ env.CONSOLE_VERSION }}
+
+      - name: Copy the test-result to host
+        if: always()
+        run: docker cp core-console-integration-test-release:/app/apps/console/test-results ./test-results
+
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: helm-integration-test-release-linux-test-results
+          path: test-results
+          retention-days: 1
 
   helm-integration-test-release-mac:
     if: false

--- a/.github/workflows/helm-integration-test-console.yml
+++ b/.github/workflows/helm-integration-test-console.yml
@@ -127,8 +127,8 @@ jobs:
 
       - name: Stop and remove console playwright
         run: |
-          docker stop console-integration-test
-          docker rm console-integration-test
+          docker stop core-console-integration-test-latest
+          docker rm core-console-integration-test-latest
 
   helm-integration-test-latest-mac:
     if: false
@@ -263,8 +263,8 @@ jobs:
 
       - name: Stop and remove console playwright
         run: |
-          docker stop console-integration-test
-          docker rm console-integration-test
+          docker stop core-console-integration-test-release
+          docker rm core-console-integration-test-release
 
   helm-integration-test-release-mac:
     if: false

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -67,12 +67,12 @@ jobs:
       - name: Copy the test-result to host
         if: always()
         run: docker cp console-integration-test:/app/apps/console/test-results ./test-results
-    
+
       - name: Upload artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: integration-test-latest-linux-test-results
           path: test-results
           retention-days: 1
 
@@ -155,7 +155,7 @@ jobs:
             --entrypoint ./entrypoint-playwright.sh \
             --name console-integration-test \
             console-playwright:${{ env.CONSOLE_VERSION }}
-      
+
       - name: Copy the test-result to host
         if: always()
         run: docker cp console-integration-test:/app/apps/console/test-results ./test-results
@@ -164,7 +164,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: integration-test-release-linux-test-results
           path: test-results
           retention-days: 1
 

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           git clone https://github.com/instill-ai/console.git
           cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:latest .
-          docker run -t --rm \
+          docker run -t \
             -e NEXT_PUBLIC_GENERAL_API_VERSION=v1beta \
             -e NEXT_PUBLIC_MODEL_API_VERSION=v1alpha \
             -e NEXT_PUBLIC_CONSOLE_EDITION=local-ce:test \
@@ -75,6 +75,11 @@ jobs:
           name: integration-test-latest-linux-test-results
           path: test-results
           retention-days: 1
+
+      - name: Stop and remove console playwright
+        run: |
+          docker stop console-integration-test
+          docker rm console-integration-test
 
       - name: Make down Instill Core
         run: |
@@ -142,7 +147,7 @@ jobs:
         run: |
           git clone -b v$CONSOLE_VERSION https://github.com/instill-ai/console.git
           cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:${{ env.CONSOLE_VERSION }} .
-          docker run -t --rm \
+          docker run -t \
             -e NEXT_PUBLIC_GENERAL_API_VERSION=v1beta \
             -e NEXT_PUBLIC_MODEL_API_VERSION=v1alpha \
             -e NEXT_PUBLIC_CONSOLE_EDITION=local-ce:test \
@@ -167,6 +172,11 @@ jobs:
           name: integration-test-release-linux-test-results
           path: test-results
           retention-days: 1
+
+      - name: Stop and remove console playwright
+        run: |
+          docker stop console-integration-test
+          docker rm console-integration-test
 
       - name: Make down Instill Core
         run: |


### PR DESCRIPTION
Because

- Console will upload test-results as artifact when the tests failed, but the workflow has some issue around, this PR fixes the issue

This commit

- fix console tests artifact upload issue
