### PR TITLE
chore(helm): add setting for a workaround to improve Instill Cloud performance

### DIFF
--- a/charts/core/templates/pipeline-backend/configmap.yaml
+++ b/charts/core/templates/pipeline-backend/configmap.yaml
@@ -33,6 +33,8 @@ data:
           vdp: /vdp
           airbyte: /local
         excludelocalconnector: {{ .Values.pipelineBackend.excludelocalconnector }}
+      instill:
+        usestaticmodellist: {{ .Values.pipelineBackend.useStaticModelList }}
     mgmtbackend:
       host: {{ template "core.mgmtBackend" . }}
       publicport: {{ template "core.mgmtBackend.publicPort" . }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -414,6 +414,7 @@ pipelineBackend:
   # -- Load the pre-built connector or not
   prebuiltConnectorEnabled: false
   excludelocalconnector: false
+  useStaticModelList: false
   # -- The configuration of Temporal Cloud
   temporal:
     hostPort:


### PR DESCRIPTION
Because

- In Instill Cloud, the Instill Model connector will frequently send GET requests to /models endpoint, as it connects to Instill Model through an external network, resulting in poor performance. Since we have a static model list in Instill Cloud for now, we can implement a temporary workaround by caching the model list to improve performance.

This commit

- Adds setting for a workaround to improve Instill Cloud performance