### PR TITLE
chore(helm): fix redis host and add extra volume mounts

### DIFF
--- a/charts/core/templates/registry/deployment.yaml
+++ b/charts/core/templates/registry/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - 'ping'
           env:
             - name: REDIS_HOST
-              value: "{{ template "core.redis" . }}"
+              value: "{{ .Values.registry.config.redis.addr }}"
       containers:
         - name: registry
           image: {{ .Values.registry.image.repository }}:{{ .Values.registry.image.tag }}
@@ -98,6 +98,9 @@ spec:
             {{- if eq .Values.registry.config.storage.type "filesystem" }}
             - name: data-volume
               mountPath: /var/lib/registry
+            {{- end }}
+            {{- with .Values.registry.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with .Values.registry.extraEnv }}
           env:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -493,7 +493,7 @@ modelBackend:
   # -- The path of configuration file for model-backend
   configPath: /model-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 4
+  dbVersion: 5
   # -- The configuration of Temporal Cloud
   temporal:
     hostPort:


### PR DESCRIPTION
Because

- We are missing `extraVolumeMounts` in registry deployment.yaml
- We have wrong redis host in registry deployment.yaml

This commit

- fix redis host and add extra volume mounts for registry service
