### PR TITLE
chore(helm): mark GPU node as no CPU resource available

### DIFF
--- a/charts/core/templates/ray-service/ray-service.yaml
+++ b/charts/core/templates/ray-service/ray-service.yaml
@@ -114,6 +114,9 @@ spec:
       maxReplicas: {{ $workerGroupSpecs.maxReplicas }}
       groupName: {{ $workerGroupSpecs.groupName }}
       rayStartParams:
+        {{- if $workerGroupSpecs.gpuWorkerGroup.enabled }}
+        num-cpus: "0"
+        {{- end }}
         {{- if $workerGroupSpecs.gpuWorkerGroup.customResource }}
         resources: {{ $workerGroupSpecs.gpuWorkerGroup.customResource }}
         {{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -687,11 +687,11 @@ rayService:
   headGroupSpec:
     resources:
       limits:
-        cpu: "0"
+        cpu: "2"
         memory: "4Gi"
         nvidia.com/gpu: 0
       requests:
-        cpu: "0"
+        cpu: "2"
         memory: "4Gi"
         nvidia.com/gpu: 0
     affinity: {}


### PR DESCRIPTION
Because

- In current setup, GPU node has CPU resources available, causing pure CPU model will sometime be scheduled onto GPU node, which is not desirable, we want CPU models to only be scheduled on CPU node.

This commit

- mark GPU node as no CPU resource available for scheduling
