### PR TITLE
chore(model_hub): add llamacode and make zephyr runs on gpu

### DIFF
--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -66,7 +66,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-zephyr-7b-dvc",
-      "tag": "f32-cpu-transformer-ray-v0.8.0"
+      "tag": "f16-1gpu-transformer-ray-v0.11.0"
     }
   },
   {
@@ -77,6 +77,16 @@
     "configuration": {
       "repository": "instill-ai/model-controlnet-dvc",
       "tag": "f16-gpuAuto-diffusers-ray-v0.8.0"
+    }
+  },
+  {
+    "id": "llamacode-7b",
+    "description": "Llamacode-7b, from Huggingface, is trained to generate text based on your prompts.",
+    "task": "TASK_TEXT_GENERATION_CHAT",
+    "model_definition": "model-definitions/github",
+    "configuration": {
+      "repository": "instill-ai/model-codellama-7b-dvc",
+      "tag": "f16-1gpu-transformer-ray-v0.11.0"
     }
   }
 ]


### PR DESCRIPTION
Because

- we are going to host more models

This commit

- add llamacode-7b
- make zephyr runs on gpu
