### PR TITLE
chore(helm): mount temporal tls volume for mgmt-backend-migration

### DIFF
--- a/charts/core/templates/mgmt-backend/deployment.yaml
+++ b/charts/core/templates/mgmt-backend/deployment.yaml
@@ -88,6 +88,9 @@ spec:
             - name: config
               mountPath: {{ .Values.mgmtBackend.configPath }}
               subPath: config.yaml
+            {{- with .Values.mgmtBackend.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         - name: mgmt-backend-init
           image: {{ .Values.mgmtBackend.image.repository }}:{{ .Values.mgmtBackend.image.tag }}
           imagePullPolicy: {{ .Values.mgmtBackend.image.pullPolicy }}


### PR DESCRIPTION
Because

- The `mgmt-backend-migration` container needs to run a Temporal workflow

This commit

- Mounts Temporal TLS volume for `mgmt-backend-migration`.
