### PR TITLE
chore(docker-compose): remove version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Not quite into self-hosting? We've got you covered with **☁️ [Instill Cloud]
 
 - **macOS or Linux** - Instill Core works on macOS or Linux, but does not support Windows yet.
 
-- **Docker and Docker Compose** - Instill Core uses Docker Compose (specifically, `Compose V2` and `Compose specification`) to run all services locally. Please install the latest stable [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) before using Instill Core.
+- **Docker and Docker Compose** - Instill Core requires Docker Engine `v25` or later and Docker Compose `v2` or later to run all services locally. Please install the latest stable [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) before using Instill Core.
 
 ## Quick Start
 

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   api_gateway:
     profiles:

--- a/docker-compose-latest.yml
+++ b/docker-compose-latest.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   api_gateway:
     profiles:

--- a/docker-compose-nvidia.yml
+++ b/docker-compose-nvidia.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   ray_server:
     deploy:

--- a/docker-compose-observe.yml
+++ b/docker-compose-observe.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   otel_collector:
     container_name: ${OTEL_COLLECTOR_HOST}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 networks:
   default:
     name: instill-network


### PR DESCRIPTION
Because

- `version` has been deprecated in the Docker Compose `v2`

This commit

- remove `version` in the compose file and update `README.md`
