### PR TITLE
ci(github): sync version to instill.tech website

### DIFF
--- a/.github/workflows/sync-version-with-website.yml
+++ b/.github/workflows/sync-version-with-website.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         # On release triggers, GITHUB_REF_NAME is the release name (e.g.
         # 'v0.10.0-beta')
-        sed -i "s/core: \".*\"/core: \"test\"/" version.mjs
+        sed -i "s/core: \".*\"/core: \"v0.32.0-beta\"/" version.mjs
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:

--- a/.github/workflows/sync-version-with-website.yml
+++ b/.github/workflows/sync-version-with-website.yml
@@ -1,0 +1,39 @@
+# This workflow will open a PR in https://github.com/instill-ai/protobufs
+# updating the API version in the OpenAPI specifications.
+
+name: Sync release version with instill.tech website
+
+on:
+  push: 
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  update-website:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout instill.tech repository
+      uses: actions/checkout@v4
+      with:
+        repository: instill-ai/instill.tech
+        token: ${{ secrets.botGitHubToken }}
+    - name: Modify the version in website
+      run: |
+        # On release triggers, GITHUB_REF_NAME is the release name (e.g.
+        # 'v0.10.0-beta')
+        sed -i "s/core: \".*\"/cire: \"${GITHUB_REF_NAME}\"/" version.mjs
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.botGitHubToken }}
+        commit-message: 'chore: update  Instill Core version'
+        title: 'docs(document): Update Instill Core version'
+        body: Sync version with latest Core release
+        branch: chore/update-api-version
+        base: main
+        draft: false

--- a/.github/workflows/sync-version-with-website.yml
+++ b/.github/workflows/sync-version-with-website.yml
@@ -31,8 +31,8 @@ jobs:
       with:
         token: ${{ secrets.botGitHubToken }}
         commit-message: 'chore: update  Instill Core version'
-        title: 'docs(document): Update Instill Core version'
+        title: 'docs(document): update Instill Core version'
         body: Sync version with latest Core release
-        branch: chore/update-api-version
+        branch: chore/update-doc-version
         base: main
         draft: false

--- a/.github/workflows/sync-version-with-website.yml
+++ b/.github/workflows/sync-version-with-website.yml
@@ -1,5 +1,5 @@
-# This workflow will open a PR in https://github.com/instill-ai/protobufs
-# updating the API version in the OpenAPI specifications.
+# This workflow will open a PR in https://github.com/instill-ai/instill.tech
+# updating the doc version in the website.
 
 name: Sync release version with instill.tech website
 

--- a/.github/workflows/sync-version-with-website.yml
+++ b/.github/workflows/sync-version-with-website.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         # On release triggers, GITHUB_REF_NAME is the release name (e.g.
         # 'v0.10.0-beta')
-        sed -i "s/core: \".*\"/core: \"${GITHUB_REF_NAME}\"/" version.mjs
+        sed -i "s/core: \".*\"/core: \"test\"/" version.mjs
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:

--- a/.github/workflows/sync-version-with-website.yml
+++ b/.github/workflows/sync-version-with-website.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         # On release triggers, GITHUB_REF_NAME is the release name (e.g.
         # 'v0.10.0-beta')
-        sed -i "s/core: \".*\"/cire: \"${GITHUB_REF_NAME}\"/" version.mjs
+        sed -i "s/core: \".*\"/core: \"${GITHUB_REF_NAME}\"/" version.mjs
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:

--- a/.github/workflows/sync-version-with-website.yml
+++ b/.github/workflows/sync-version-with-website.yml
@@ -4,7 +4,6 @@
 name: Sync release version with instill.tech website
 
 on:
-  push: 
   release:
     types: [published]
 
@@ -26,7 +25,7 @@ jobs:
       run: |
         # On release triggers, GITHUB_REF_NAME is the release name (e.g.
         # 'v0.10.0-beta')
-        sed -i "s/core: \".*\"/core: \"v0.32.0-beta\"/" version.mjs
+        sed -i "s/core: \".*\"/core: \"${GITHUB_REF_NAME}\"/" version.mjs
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:


### PR DESCRIPTION
Because

- We want to sync the version to instill.tech website automatically.

This commit

- Adds Github Action workflow for this.
