### PR TITLE
chore(community): migrate community content

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,303 @@
+{
+  "projectName": "instill-core",
+  "projectOwner": "instill-ai",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "imageSize": 100,
+  "contributorsPerLine": 5,
+  "contributorsSortAlphabetically": false,
+  "commit": true,
+  "commitConvention": "angular",
+  "linkToUsage": false,
+  "skipCi": true,
+  "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-31-blue.svg?label=All%20Contributors)](#contributors-)",
+  "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
+  "files": [
+    "README.md"
+  ],
+  "contributors": [
+    {
+      "login": "VibhorGits",
+      "name": "Vibhor Bhatt",
+      "avatar_url": "https://avatars.githubusercontent.com/u/110928899?v=4",
+      "profile": "https://github.com/VibhorGits",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "miguel-ortiz-marin",
+      "name": "Miguel Ortiz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/89418691?v=4",
+      "profile": "https://github.com/miguel-ortiz-marin",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "sajdakabir",
+      "name": "Sajda Kabir",
+      "avatar_url": "https://avatars.githubusercontent.com/u/86569763?v=4",
+      "profile": "https://github.com/sajdakabir",
+      "contributions": [
+        "bug"
+      ]
+    },
+    {
+      "login": "chenhunghan",
+      "name": "Henry Chen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1474479?v=4",
+      "profile": "https://github.com/chenhunghan",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "HariBhandari07",
+      "name": "Hari Bhandari",
+      "avatar_url": "https://avatars.githubusercontent.com/u/34328907?v=4",
+      "profile": "https://github.com/HariBhandari07",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "geeksambhu",
+      "name": "Shiva Gaire",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9899283?v=4",
+      "profile": "https://github.com/geeksambhu",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "syedzubeen",
+      "name": "Zubeen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/14253061?v=4",
+      "profile": "https://github.com/syedzubeen",
+      "contributions": [
+        "example"
+      ]
+    },
+    {
+      "login": "ShihChun-H",
+      "name": "ShihChun-H",
+      "avatar_url": "https://avatars.githubusercontent.com/u/143982976?v=4",
+      "profile": "https://github.com/ShihChun-H",
+      "contributions": [
+        "content",
+        "tutorial"
+      ]
+    },
+    {
+      "login": "eltociear",
+      "name": "Ikko Eltociear Ashimine",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22633385?v=4",
+      "profile": "https://github.com/eltociear",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "FarukhS52",
+      "name": "Farookh Zaheer Siddiqui",
+      "avatar_url": "https://avatars.githubusercontent.com/u/129654632?v=4",
+      "profile": "https://github.com/FarukhS52",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "diamondsea",
+      "name": "Brian Gallagher",
+      "avatar_url": "https://avatars.githubusercontent.com/u/847589?v=4",
+      "profile": "https://github.com/diamondsea",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "hairyputtar",
+      "name": "hairyputtar",
+      "avatar_url": "https://avatars.githubusercontent.com/u/148847552?v=4",
+      "profile": "https://github.com/hairyputtar",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "dmarx",
+      "name": "David Marx",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1466881?v=4",
+      "profile": "https://github.com/dmarx",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "DenizParlak",
+      "name": "Deniz Parlak",
+      "avatar_url": "https://avatars.githubusercontent.com/u/11199794?v=4",
+      "profile": "https://github.com/DenizParlak",
+      "contributions": [
+        "test"
+      ]
+    },
+    {
+      "login": "bryan107",
+      "name": "Po-Yu Chen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8025085?v=4",
+      "profile": "https://github.com/bryan107",
+      "contributions": [
+        "example"
+      ]
+    },
+    {
+      "login": "EiffelFly",
+      "name": "Po Chun Chiu",
+      "avatar_url": "https://avatars.githubusercontent.com/u/57251712?v=4",
+      "profile": "https://github.com/EiffelFly",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "Sarthak-instill",
+      "name": "Sarthak",
+      "avatar_url": "https://avatars.githubusercontent.com/u/134260133?v=4",
+      "profile": "https://github.com/Sarthak-instill",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "heiruwu",
+      "name": "HR Wu",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5631010?v=4",
+      "profile": "https://github.com/heiruwu",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "Phelan164",
+      "name": "phelan",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2509508?v=4",
+      "profile": "https://github.com/Phelan164",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "donch1989",
+      "name": "Chang, Hui-Tang",
+      "avatar_url": "https://avatars.githubusercontent.com/u/441005?v=4",
+      "profile": "https://github.com/donch1989",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "xiaofei-du",
+      "name": "Xiaofei Du",
+      "avatar_url": "https://avatars.githubusercontent.com/u/66248476?v=4",
+      "profile": "https://github.com/xiaofei-du",
+      "contributions": [
+        "code",
+        "doc"
+      ]
+    },
+    {
+      "login": "pinglin",
+      "name": "Ping-Lin Chang",
+      "avatar_url": "https://avatars.githubusercontent.com/u/628430?v=4",
+      "profile": "https://github.com/pinglin",
+      "contributions": [
+        "code",
+        "doc"
+      ]
+    },
+    {
+      "login": "tonywang10101",
+      "name": "Tony Wang",
+      "avatar_url": "https://avatars.githubusercontent.com/u/78333580?v=4",
+      "profile": "https://github.com/tonywang10101",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "Pratikdate",
+      "name": "Pratik date",
+      "avatar_url": "https://avatars.githubusercontent.com/u/91735895?v=4",
+      "profile": "https://github.com/Pratikdate",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "jvallesm",
+      "name": "Juan Vallés",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3977183?v=4",
+      "profile": "https://github.com/jvallesm",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "iamnamananand996",
+      "name": "Naman Anand",
+      "avatar_url": "https://avatars.githubusercontent.com/u/31537362?v=4",
+      "profile": "https://github.com/iamnamananand996",
+      "contributions": [
+        "code",
+        "doc"
+      ]
+    },
+    {
+      "login": "totuslink",
+      "name": "totuslink",
+      "avatar_url": "https://avatars.githubusercontent.com/u/78023102?v=4",
+      "profile": "https://github.com/totuslink",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "praharshjain",
+      "name": "Praharsh Jain",
+      "avatar_url": "https://avatars.githubusercontent.com/u/12197448?v=4",
+      "profile": "https://github.com/praharshjain",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "Smartmind12",
+      "name": "Utsav Paul",
+      "avatar_url": "https://avatars.githubusercontent.com/u/91927689?v=4",
+      "profile": "https://github.com/Smartmind12",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "CaCaBlocker",
+      "name": "CaCaBlocker",
+      "avatar_url": "https://avatars.githubusercontent.com/u/87882515?v=4",
+      "profile": "https://github.com/CaCaBlocker",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "rsmelo92",
+      "name": "Rafael Melo",
+      "avatar_url": "https://avatars.githubusercontent.com/u/16295402?v=4",
+      "profile": "https://github.com/rsmelo92",
+      "contributions": [
+        "code"
+      ]
+    }
+  ]
+}

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,11 +7,9 @@ We appreciate your contribution to this amazing project! Any form of engagement 
 - roadmap suggestion
 - ...and so on!
 
-Please refer to the [community contributing section](https://github.com/instill-ai/community#contributing) for more details.
-
 ## Development and codebase contribution
 
-Before delving into the details to come up with your first PR, please familiarise yourself with the project structure of [Instill Core](https://github.com/instill-ai/community#instill-core).
+Before delving into the details to come up with your first PR, please familiarise yourself with the project structure of [Instill Core](https://github.com/instill-ai/instill-core).
 
 ### Prerequisites
 

--- a/.github/triage.md
+++ b/.github/triage.md
@@ -1,0 +1,62 @@
+# Issues Triage Process
+
+The triage process is designed to swiftly categorize new issues and pull requests (PRs) and take appropriate actions whenever possible.
+
+As a new issue/PR is created, the community initiates conversations, applies suitable labels, and seeks additional information.
+
+At Instill AI, we conduct regular triage meetings. These meetings focus on unresolved issues/PRs where consensus has not been reached, and aim to determine whether and when they should be incorporated into our roadmap.
+
+## Triage Stages
+
+| Name   | Description                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Triage | When a new issue/PR is opened, it is automatically labeled as `need triage``. Maintainers assign core members as reviewers to assess the issue/PR's characteristics. Reviewers initiate conversations with the creator of the issue/PR and apply relevant labels. If there's consensus and the issue/PR requires detailed planning, reviewers remove the `need triage`` label and add the `linear` label. |
+| Plan   | Issues/PRs with the `linear` label are thoroughly reviewed and need to be planned. Reviewers determine if the issue/PR is suitable for community contribution, whether it can be added to the backlog, and discuss its potential inclusion in the roadmap and the timing thereof.                                                                                                                         |
+
+We anticipate that most issues/PRs can follow this path, leading to efficient asynchronous resolution without waiting for triage meetings. Issues/PRs labeled as `need discussion` will be addressed during these triage meetings.
+
+👉 Please refer to the [triage process diagram](https://app.eraser.io/workspace/0cadbV6boFtr9NUcAGMH?elements=4FnFqsyPSnm7QMlVlvnFkg) for visual representation.
+
+## Labels
+
+GitHub labels assist in annotating issues/PRs with additional information. Our community uses labels, as outlined below, to convey information and facilitate decision-making regarding issues/PRs.
+
+### Communication Labels
+
+These labels convey the status of the triage process for an issue/PR and indicate areas where community contribution is needed. Many communication labels are replaced by other labels as the triage process progresses and the issue enters active development. For instance, the `help wanted` label is removed once an issue moves into active development and a community member takes ownership. Below are the labels in this category:
+
+| <div style="width:150px">Label</div> | Indicates that                                                                                                                                  |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `need triage`                        | Issue/PR needs triaging                                                                                                                         |
+| `question`                           | The issue/PR creator needs to provide more information for meaningful triaging. When adding this label, comment about the required information. |
+| `need discussion`                    | This issue/PR necessitates discussion during triage meetings. When adding this label, comment about what aspects require discussion.            |
+| `good first issue`                   | Issue suitable for first-time contributors                                                                                                      |
+| `help wanted`                        | Issue complexity suitable for external contributors                                                                                             |
+
+### Metadata Labels
+
+These labels enrich issues/PRs with metadata to aid the triage process and active development. These labels may not be removed from issues/PRs, although their values may change as development progresses. For example, the priority label may change from `priority: low` to `priority: high` as the roadmap is updated. Here is the list of labels in this category:
+
+| <div style="width:150px">Label</div> | Indicates that                                                                                                                                                                                                                        |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<project>`                          | Instill Project related to this issue/PR. E.g., 'instill vdp', 'instill model', 'instill core', 'instill console', 'instill cli' and 'instill sdk'                                                                                    |
+| `<project: component>`               | Major service associated with this issue/PR. E.g., 'vdp: pipeline-backend', 'vdp: connector-backend' and 'model: model-backend'                                                                                                       |
+| `feature`                            | New feature request                                                                                                                                                                                                                   |
+| `improvement`                        | Enhancement of existing features                                                                                                                                                                                                      |
+| `bug`                                | Issue indicating malfunction                                                                                                                                                                                                          |
+| `duplicate`                          | Duplicate issue/PR already exists                                                                                                                                                                                                     |
+| `stale`                              | Issue/PR open with no activity for too long                                                                                                                                                                                           |
+| `wontfix`                            | Issue will not be worked on                                                                                                                                                                                                           |
+| `priority: critical`                 | Issue causing a major outage or disruption for all users without any known workaround. The issue must be fixed immediately, taking precedence over other work. Should receive updates at least once per day.                          |
+| `priority: high`                     | Issue important to a large percentage of users, with a workaround. Issues that are significantly ugly or painful, especially first-use or install-time issues. Issues with workarounds that would otherwise be ` priority: critical`. |
+| `priority: medium`                   | Issue relevant to core functions, but not impeding progress. Important, but not urgent.                                                                                                                                               |
+| `priority: low`                      | Relatively minor issue not relevant to core functions or only affecting user experience. Good-to-have changes/fixes, but not necessary.                                                                                               |
+
+### Status Labels
+
+These labels will help in planing and tracking active development activities for a issue/PR:
+
+| Label     | Indicates that                                         |
+| --------- | ------------------------------------------------------ |
+| `linear`  | Issue/PR fully triaged and moved to the Plan stage     |
+| `roadmap` | Issue/PR added to the roadmap with a clear target date |

--- a/.github/workflows/add-comment-to-issue.yml
+++ b/.github/workflows/add-comment-to-issue.yml
@@ -1,0 +1,40 @@
+name: Add Comment to Issue
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add-comment-to-help-wanted:
+    if: github.event.label.name == 'help wanted'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            This issue is available for anyone to work on.
+
+            - Read our [Contributing Guidelines](https://github.com/instill-ai/.github/blob/main/.github/CONTRIBUTING.md)
+            - Make sure to **reference** this issue in your pull request
+
+            **:sparkles: Thank you for your contribution! :sparkles:**
+  add-comment-to-good-first-issue:
+    if: github.event.label.name == 'good first issue'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            This issue is a great way to kick-start your journey with our project, or to make a positive impact on open-source development. Jump in!
+
+            - Check out our [Contributing Guidelines](https://github.com/instill-ai/.github/blob/main/.github/CONTRIBUTING.md) for a smooth experience
+            - Remember to **[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)** your pull request to this issue
+
+            **:sparkles: Thank you for your contribution! :sparkles:**

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
-# Instill Core
+# instill-core
 
 [![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/instill-ai/instill-core?&label=Release&color=blue&include_prereleases&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTQgOEg3VjRIMjNWMTdIMjFDMjEgMTguNjYgMTkuNjYgMjAgMTggMjBDMTYuMzQgMjAgMTUgMTguNjYgMTUgMTdIOUM5IDE4LjY2IDcuNjYgMjAgNiAyMEM0LjM0IDIwIDMgMTguNjYgMyAxN0gxVjEyTDQgOFpNMTggMThDMTguNTUgMTggMTkgMTcuNTUgMTkgMTdDMTkgMTYuNDUgMTguNTUgMTYgMTggMTZDMTcuNDUgMTYgMTcgMTYuNDUgMTcgMTdDMTcgMTcuNTUgMTcuNDUgMTggMTggMThaTTQuNSA5LjVMMi41NCAxMkg3VjkuNUg0LjVaTTYgMThDNi41NSAxOCA3IDE3LjU1IDcgMTdDNyAxNi40NSA2LjU1IDE2IDYgMTZDNS40NSAxNiA1IDE2LjQ1IDUgMTdDNSAxNy41NSA1LjQ1IDE4IDYgMThaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K)](https://github.com/instill-ai/instill-core/releases)
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/instill-ai)](https://artifacthub.io/packages/helm/instill-ai/instill-core)
-[![Discord](https://img.shields.io/discord/928991293856681984?color=blue&label=Discord&logo=discord&logoColor=fff)](https://discord.gg/sevxWsqpGh)
+[![Artifact Hub](https://img.shields.io/endpoint?labelColor=gray&color=blue&url=https://artifacthub.io/badge/repository/instill-ai)](https://artifacthub.io/packages/helm/instill-ai/core)
+[![Discord](https://img.shields.io/discord/928991293856681984?color=blue&label=Discord&logo=discord&logoColor=fff)](https://discord.gg/sevxWsqpGh) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-31-blue.svg?label=All%20Contributors)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 [![Integration Test](https://img.shields.io/github/actions/workflow/status/instill-ai/instill-core/integration-test-latest.yml?branch=main&label=Integration%20Test&logoColor=fff&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wIDEuNzVDMCAwLjc4NCAwLjc4NCAwIDEuNzUgMEg1LjI1QzYuMjE2IDAgNyAwLjc4NCA3IDEuNzVWNS4yNUM3IDUuNzE0MTMgNi44MTU2MyA2LjE1OTI1IDYuNDg3NDQgNi40ODc0NEM2LjE1OTI1IDYuODE1NjMgNS43MTQxMyA3IDUuMjUgN0g0VjExQzQgMTEuMjY1MiA0LjEwNTM2IDExLjUxOTYgNC4yOTI4OSAxMS43MDcxQzQuNDgwNDMgMTEuODk0NiA0LjczNDc4IDEyIDUgMTJIOVYxMC43NUM5IDkuNzg0IDkuNzg0IDkgMTAuNzUgOUgxNC4yNUMxNS4yMTYgOSAxNiA5Ljc4NCAxNiAxMC43NVYxNC4yNUMxNiAxNC43MTQxIDE1LjgxNTYgMTUuMTU5MiAxNS40ODc0IDE1LjQ4NzRDMTUuMTU5MiAxNS44MTU2IDE0LjcxNDEgMTYgMTQuMjUgMTZIMTAuNzVDMTAuMjg1OSAxNiA5Ljg0MDc1IDE1LjgxNTYgOS41MTI1NiAxNS40ODc0QzkuMTg0MzcgMTUuMTU5MiA5IDE0LjcxNDEgOSAxNC4yNVYxMy41SDVDNC4zMzY5NiAxMy41IDMuNzAxMDcgMTMuMjM2NiAzLjIzMjIzIDEyLjc2NzhDMi43NjMzOSAxMi4yOTg5IDIuNSAxMS42NjMgMi41IDExVjdIMS43NUMxLjI4NTg3IDcgMC44NDA3NTIgNi44MTU2MyAwLjUxMjU2MyA2LjQ4NzQ0QzAuMTg0Mzc0IDYuMTU5MjUgMCA1LjcxNDEzIDAgNS4yNUwwIDEuNzVaTTEuNzUgMS41QzEuNjgzNyAxLjUgMS42MjAxMSAxLjUyNjM0IDEuNTczMjIgMS41NzMyMkMxLjUyNjM0IDEuNjIwMTEgMS41IDEuNjgzNyAxLjUgMS43NVY1LjI1QzEuNSA1LjM4OCAxLjYxMiA1LjUgMS43NSA1LjVINS4yNUM1LjMxNjMgNS41IDUuMzc5ODkgNS40NzM2NiA1LjQyNjc4IDUuNDI2NzhDNS40NzM2NiA1LjM3OTg5IDUuNSA1LjMxNjMgNS41IDUuMjVWMS43NUM1LjUgMS42ODM3IDUuNDczNjYgMS42MjAxMSA1LjQyNjc4IDEuNTczMjJDNS4zNzk4OSAxLjUyNjM0IDUuMzE2MyAxLjUgNS4yNSAxLjVIMS43NVpNMTAuNzUgMTAuNUMxMC42ODM3IDEwLjUgMTAuNjIwMSAxMC41MjYzIDEwLjU3MzIgMTAuNTczMkMxMC41MjYzIDEwLjYyMDEgMTAuNSAxMC42ODM3IDEwLjUgMTAuNzVWMTQuMjVDMTAuNSAxNC4zODggMTAuNjEyIDE0LjUgMTAuNzUgMTQuNUgxNC4yNUMxNC4zMTYzIDE0LjUgMTQuMzc5OSAxNC40NzM3IDE0LjQyNjggMTQuNDI2OEMxNC40NzM3IDE0LjM3OTkgMTQuNSAxNC4zMTYzIDE0LjUgMTQuMjVWMTAuNzVDMTQuNSAxMC42ODM3IDE0LjQ3MzcgMTAuNjIwMSAxNC40MjY4IDEwLjU3MzJDMTQuMzc5OSAxMC41MjYzIDE0LjMxNjMgMTAuNSAxNC4yNSAxMC41SDEwLjc1WiIgZmlsbD0id2hpdGUiLz4KPC9zdmc+Cg==)](https://github.com/instill-ai/instill-core/actions/workflows/integration-test-latest.yml?branch=main&event=push)
+
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/instill-ai/.github/main/img/instill-projects.svg" >
   <br>
-    <em>Open-source orchestrator for data, AI and pipelines</em>
+    <em>Open-source orchestration platform for data, AI and pipelines</em>
 </div>
 
 <br>
 
-Explore **🔮 Instill Core**, the open-source orchestrator comprising a collection of source-available projects designed to streamline every aspect of building versatile AI features with unstructured data.
+Explore **🔮 Instill Core**, the open-source orchestration platform comprising a collection of source-available projects designed to streamline every aspect of building versatile AI features with unstructured data.
 
 <details>
   <summary><b>💧 Instill VDP</b>: Unstructured data, AI and pipeline orchestration</summary><br>
@@ -26,7 +29,7 @@ Explore **🔮 Instill Core**, the open-source orchestrator comprising a collect
 
   <br>
 
-  **Instill VDP**, also known as **VDP (Versatile Data Pipeline)**, serves as a powerful data orchestrator tailored to address unstructured data ETL challenges.
+  **Instill VDP**, also known as **VDP (Versatile Data Pipeline)**, serves as a powerful data orchestration tool tailored to address unstructured data ETL challenges.
 
   - Simplify the journey of processing unstructured data from diverse sources, including AI applications, cloud/on-prem storage, and IoT devices. Utilize AI models and embed business logic to transform raw data into meaningful insights and actionable formats. Efficiently load processed data to warehouses, applications, or other destinations.
   - Build flexible, durable pipelines with features like failover, automatic retries, rate limiting, and batching to handle high-volume data straight out of the box.
@@ -132,11 +135,99 @@ To dive into Instill Core and Instill Cloud, you have a few options:
 
 ## Contributing
 
-Please refer to the [Contributing Guidelines](./.github/CONTRIBUTING.md) for more details.
+We welcome contributions from the community! Whether you're a developer, designer, writer, or user, there are multiple ways to contribute:
 
-## Be Part of Us
+### Issue Guidelines
 
-We strongly believe in the power of community collaboration and deeply value your contributions. Head over to our [Community](https://github.com/instill-ai/community) repository, the central hub for discussing our open-source projects, raising issues, and sharing your brilliant ideas.
+We foster a friendly and inclusive environment for issue reporting. Before creating an issue, check if it already exists. Use clear language and provide reproducible steps for bugs. Accurately tag the issue (bug, improvement, question, etc.).
+
+### Code Contributions
+
+Please refer to the [Contributing Guidelines](./.github/CONTRIBUTING.md) for more details. Your code-driven innovations are more than welcome!
+
+## Community
+
+We are committed to providing a respectful and welcoming atmosphere for all contributors. Please review our [Code of Conduct](https://github.com/instill-ai/.github/blob/main/.github/CODE_OF_CONDUCT.md) to understand our standards.
+
+### Efficient Triage Process
+
+We have implemented a streamlined [Issues Triage Process](.github/triage.md) aimed at swiftly categorizing new issues and pull requests (PRs), allowing us to take prompt and appropriate actions.
+
+### Engage in Dynamic Discussions and Seek Support
+
+Head over to our [Discussions](../../discussions) section for engaging conversations:
+
+- [General](https://github.com/orgs/instill-ai/discussions/categories/general): Chat about anything related to our projects.
+- [Polls](https://github.com/orgs/instill-ai/discussions/categories/polls): Participate in community polls.
+- [Q&A](https://github.com/orgs/instill-ai/discussions/categories/q-a): Seek help or ask questions; our community members and maintainers are here to assist.
+- [Show and Tell](https://github.com/orgs/instill-ai/discussions/categories/show-and-tell): Showcase projects you've created using our tools.
+
+Alternatively, you can also join our vibrant [Discord](https://discord.gg/sevxWsqpGh) community and direct your queries to the #ask-for-help channel. We're dedicated to supporting you every step of the way.
+
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/VibhorGits"><img src="https://avatars.githubusercontent.com/u/110928899?v=4" width="100px;" alt=""/><br /><sub><b>Vibhor Bhatt</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/miguel-ortiz-marin"><img src="https://avatars.githubusercontent.com/u/89418691?v=4" width="100px;" alt=""/><br /><sub><b>Miguel Ortiz</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/sajdakabir"><img src="https://avatars.githubusercontent.com/u/86569763?v=4" width="100px;" alt=""/><br /><sub><b>Sajda Kabir</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/chenhunghan"><img src="https://avatars.githubusercontent.com/u/1474479?v=4" width="100px;" alt=""/><br /><sub><b>Henry Chen</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/HariBhandari07"><img src="https://avatars.githubusercontent.com/u/34328907?v=4" width="100px;" alt=""/><br /><sub><b>Hari Bhandari</b></sub></a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/geeksambhu"><img src="https://avatars.githubusercontent.com/u/9899283?v=4" width="100px;" alt=""/><br /><sub><b>Shiva Gaire</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/syedzubeen"><img src="https://avatars.githubusercontent.com/u/14253061?v=4" width="100px;" alt=""/><br /><sub><b>Zubeen</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/ShihChun-H"><img src="https://avatars.githubusercontent.com/u/143982976?v=4" width="100px;" alt=""/><br /><sub><b>ShihChun-H</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/eltociear"><img src="https://avatars.githubusercontent.com/u/22633385?v=4" width="100px;" alt=""/><br /><sub><b>Ikko Eltociear Ashimine</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/FarukhS52"><img src="https://avatars.githubusercontent.com/u/129654632?v=4" width="100px;" alt=""/><br /><sub><b>Farookh Zaheer Siddiqui</b></sub></a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/diamondsea"><img src="https://avatars.githubusercontent.com/u/847589?v=4" width="100px;" alt=""/><br /><sub><b>Brian Gallagher</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/hairyputtar"><img src="https://avatars.githubusercontent.com/u/148847552?v=4" width="100px;" alt=""/><br /><sub><b>hairyputtar</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/dmarx"><img src="https://avatars.githubusercontent.com/u/1466881?v=4" width="100px;" alt=""/><br /><sub><b>David Marx</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/DenizParlak"><img src="https://avatars.githubusercontent.com/u/11199794?v=4" width="100px;" alt=""/><br /><sub><b>Deniz Parlak</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/bryan107"><img src="https://avatars.githubusercontent.com/u/8025085?v=4" width="100px;" alt=""/><br /><sub><b>Po-Yu Chen</b></sub></a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/EiffelFly"><img src="https://avatars.githubusercontent.com/u/57251712?v=4" width="100px;" alt=""/><br /><sub><b>Po Chun Chiu</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/Sarthak-instill"><img src="https://avatars.githubusercontent.com/u/134260133?v=4" width="100px;" alt=""/><br /><sub><b>Sarthak</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/heiruwu"><img src="https://avatars.githubusercontent.com/u/5631010?v=4" width="100px;" alt=""/><br /><sub><b>HR Wu</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/Phelan164"><img src="https://avatars.githubusercontent.com/u/2509508?v=4" width="100px;" alt=""/><br /><sub><b>phelan</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/donch1989"><img src="https://avatars.githubusercontent.com/u/441005?v=4" width="100px;" alt=""/><br /><sub><b>Chang, Hui-Tang</b></sub></a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/xiaofei-du"><img src="https://avatars.githubusercontent.com/u/66248476?v=4" width="100px;" alt=""/><br /><sub><b>Xiaofei Du</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/pinglin"><img src="https://avatars.githubusercontent.com/u/628430?v=4" width="100px;" alt=""/><br /><sub><b>Ping-Lin Chang</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/tonywang10101"><img src="https://avatars.githubusercontent.com/u/78333580?v=4" width="100px;" alt=""/><br /><sub><b>Tony Wang</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/Pratikdate"><img src="https://avatars.githubusercontent.com/u/91735895?v=4" width="100px;" alt=""/><br /><sub><b>Pratik date</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/jvallesm"><img src="https://avatars.githubusercontent.com/u/3977183?v=4" width="100px;" alt=""/><br /><sub><b>Juan Vallés</b></sub></a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/iamnamananand996"><img src="https://avatars.githubusercontent.com/u/31537362?v=4" width="100px;" alt=""/><br /><sub><b>Naman Anand</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/totuslink"><img src="https://avatars.githubusercontent.com/u/78023102?v=4" width="100px;" alt=""/><br /><sub><b>totuslink</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/praharshjain"><img src="https://avatars.githubusercontent.com/u/12197448?v=4" width="100px;" alt=""/><br /><sub><b>Praharsh Jain</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/Smartmind12"><img src="https://avatars.githubusercontent.com/u/91927689?v=4" width="100px;" alt=""/><br /><sub><b>Utsav Paul</b></sub></a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/CaCaBlocker"><img src="https://avatars.githubusercontent.com/u/87882515?v=4" width="100px;" alt=""/><br /><sub><b>CaCaBlocker</b></sub></a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/rsmelo92"><img src="https://avatars.githubusercontent.com/u/16295402?v=4" width="100px;" alt=""/><br /><sub><b>Rafael Melo</b></sub></a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 
 ## License
 


### PR DESCRIPTION
Because

- we are going to archive the [community](https://github.com/instill-ai/community) and move the content to the `instill-core` repo

This commit

- integrate the `community` repo content with the `instill-core` repo 
