### PR TITLE
chore(helm): use fixed version of kuberay

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -651,6 +651,10 @@ console:
       maxUnavailable:
 # -- The configuration of KubeRay Operator
 kuberay-operator:
+  image:
+    repository: quay.io/kuberay/operatore
+    tag: v1.1.1
+    pullPolicy: IfNotPresent
   fullnameOverride: ""
   watchNamespace:
     - "instill-ai"

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -652,7 +652,7 @@ console:
 # -- The configuration of KubeRay Operator
 kuberay-operator:
   image:
-    repository: quay.io/kuberay/operatore
+    repository: quay.io/kuberay/operator
     tag: v1.1.1
     pullPolicy: IfNotPresent
   fullnameOverride: ""

--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -50,7 +50,7 @@
     "visibility": "VISIBILITY_PUBLIC",
     "task": "TASK_TEXT_TO_IMAGE",
     "region": "REGION_GCP_EUROPE_WEST4",
-    "hardware": "NVIDIA_L4",
+    "hardware": "NVIDIA_A100",
     "version": "v0.1.0",
     "configuration": {}
   },


### PR DESCRIPTION
Because

- Using nightly build of 3rd party dependency might encounter unwanted instability

This commit

- use stable version of kuberay
- update `stable-diffusion-xl` hardware type to avoid OOM
