### PR TITLE
fix(artifact): modify healthy check request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ dev
 
 # Python
 __pycache__
+
+# Macbook
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -331,7 +331,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -f  http://localhost:8082/v1alpha/health/artifact",
+          "curl -f  http://${ARTIFACT_BACKEND_HOST}:${ARTIFACT_BACKEND_PUBLICPORT}/v1alpha/health/artifact",
         ]
       start_period: 20s
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -331,7 +331,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget --no-verbose --tries=1 --spider http://${ARTIFACT_BACKEND_HOST}:${ARTIFACT_BACKEND_PUBLICPORT}/v1alpha/health/artifact",
+          "curl -f  http://localhost:8082/v1alpha/health/artifact",
         ]
       start_period: 20s
       interval: 30s


### PR DESCRIPTION
Because

wrong health check, docker compose fails in healthcheck of artifact backend

This commit

using `cur`l to send `GET` method instead of `HEAD` method from `wget` 
