### PR TITLE
chore(artifact): use correct db version

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -546,7 +546,7 @@ artifactBackend:
   # -- The path of configuration file for artifact-backend
   configPath: /artifact-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 1
+  dbVersion: 2
   # -- Set the service account to be used, default if left empty
   serviceAccountName: ""
   # -- Mount the service account token


### PR DESCRIPTION
Because

db migration is outdated

This commit

use correct version