### PR TITLE
feat(mgmt): run migration only on main cluster in mgmt-backend

### DIFF
--- a/charts/core/templates/mgmt-backend/deployment.yaml
+++ b/charts/core/templates/mgmt-backend/deployment.yaml
@@ -76,6 +76,7 @@ spec:
             - name: TEMPORAL_CLI_ADDRESS
               value: "{{ template "core.temporal" . }}-frontend:{{ template "core.temporal.frontend.grpcPort" . }}"
         {{- end }}
+        {{- if .Values.isPrimaryCluster }}
         - name: mgmt-backend-migration
           image: {{ .Values.mgmtBackend.image.repository }}:{{ .Values.mgmtBackend.image.tag }}
           imagePullPolicy: {{ .Values.mgmtBackend.image.pullPolicy }}
@@ -91,6 +92,7 @@ spec:
             {{- with .Values.mgmtBackend.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- end }}
         - name: mgmt-backend-init
           image: {{ .Values.mgmtBackend.image.repository }}:{{ .Values.mgmtBackend.image.tag }}
           imagePullPolicy: {{ .Values.mgmtBackend.image.pullPolicy }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -11,6 +11,8 @@ updateStrategy:
   rollingUpdate:
     maxSurge: 1
     maxUnavailable: 0
+# -- Set the cluster as the primary one in a multi-region environment.
+isPrimaryCluster: true
 # -- Logging level: debug, info, warning, error or fatal
 logLevel: info
 # -- Enable development mode


### PR DESCRIPTION
Because

- Cloud features require migrations to be run on a given cluster.

This commit

- Creates the `isPrimaryCluster` variable and uses it to enable the migration process on `mgmt-backend`.
