### PR TITLE
chore(model): add pvc for deployment config

### DIFF
--- a/charts/core/templates/_helpers.tpl
+++ b/charts/core/templates/_helpers.tpl
@@ -450,6 +450,10 @@ internal TLS secret names
 {{/*
 Persistent Volume Claims
 */}}
+{{- define "core.modelConfigDataVolume" -}}
+  {{- printf "%s-model-config-data-volume" (include "core.fullname" .) -}}
+{{- end -}}
+
 {{- define "core.registryDataVolume" -}}
   {{- printf "%s-registry-data-volume" (include "core.fullname" .) -}}
 {{- end -}}

--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -51,7 +51,7 @@ data:
       {{- end }}
     rayserver:
       grpcuri: {{ include "core.ray" . }}:{{ include "core.ray.serveGrpcPort" . }}
-      modelstore: /model-backend
+      modelstore: /model-config
       vram: {{ .Values.rayService.vram }}
     database:
       username: {{ default (include "core.database.username" .) .Values.database.external.username }}

--- a/charts/core/templates/model-backend/deployment.yaml
+++ b/charts/core/templates/model-backend/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.tags.model -}}
+{{- $modelConfig := .Values.persistence.persistentVolumeClaim.modelConfig -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -125,6 +126,15 @@ spec:
               value: "{{ template "core.ray" . }}"
             - name: RAY_SERVER_SERVE_PORT
               value: "{{ template "core.ray.servePort" . }}"
+        - name: chmod-model-config
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          image: busybox
+          command: ["sh", "-c", "chmod -R 777 /model-config"]
+          volumeMounts:
+          - name: model-config
+            mountPath: /model-config
       containers:
         - name: model-backend-worker
           image: {{ .Values.modelBackend.image.repository }}:{{ .Values.modelBackend.image.tag }}
@@ -141,6 +151,8 @@ spec:
             - name: config
               mountPath: {{ .Values.modelBackend.configPath }}
               subPath: config.yaml
+            - name: model-config
+              mountPath: /model-config
             {{- with .Values.modelBackend.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -174,6 +186,8 @@ spec:
             - name: config
               mountPath: {{ .Values.modelBackend.configPath }}
               subPath: config.yaml
+            - name: model-config
+              mountPath: /model-config
             {{- if .Values.internalTLS.enabled }}
             - name: model-internal-certs
               mountPath: "/etc/instill-ai/model/ssl/model"
@@ -192,6 +206,16 @@ spec:
         - name: config
           configMap:
             name: {{ template "core.modelBackend" . }}
+        - name: model-config
+        {{- if not .Values.persistence.enabled }}
+          emptyDir: {}
+        {{- else if $modelConfig.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ $modelConfig.existingClaim }}
+        {{- else }}
+          persistentVolumeClaim:
+            claimName: core-model-config-data-volume
+        {{- end }}
         {{- if .Values.internalTLS.enabled }}
         - name: model-internal-certs
           secret:

--- a/charts/core/templates/pvc.yaml
+++ b/charts/core/templates/pvc.yaml
@@ -1,4 +1,36 @@
 {{- if .Values.persistence.enabled }}
+{{- if .Values.tags.model -}}
+{{- $modelConfig := .Values.persistence.persistentVolumeClaim.modelConfig -}}
+{{- if not $modelConfig.existingClaim }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "core.modelConfigDataVolume" . }}
+  annotations:
+  {{- range $key, $value := $modelConfig.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- if eq .Values.persistence.resourcePolicy "keep" }}
+    helm.sh/resource-policy: keep
+  {{- end }}
+  labels:
+    {{- include "core.labels" . | nindent 4 }}
+    app.kubernetes.io/component: model-backend
+spec:
+  accessModes:
+    - {{ $modelConfig.accessMode }}
+  resources:
+    requests:
+      storage: {{ $modelConfig.size }}
+  {{- if $modelConfig.storageClass }}
+    {{- if eq "-" $modelConfig.storageClass }}
+  storageClassName: ""
+    {{- else }}
+  storageClassName: {{ $modelConfig.storageClass }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- if eq .Values.registry.config.storage.type "filesystem" }}
 {{- $registry := .Values.persistence.persistentVolumeClaim.registry -}}
 {{- if not $registry.existingClaim }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -205,6 +205,13 @@ persistence:
   resourcePolicy: "keep"
   persistentVolumeClaim:
     # If external database is used, the following settings for database will be ignored
+    modelConfig:
+      existingClaim: ""
+      storageClass: ""
+      subPath: ""
+      accessMode: ReadWriteOnce
+      size: 512Mi
+      annotations: {}
     database:
       existingClaim: ""
       storageClass: ""
@@ -1431,6 +1438,7 @@ registry:
           auth_provider_x509_cert_url:
           client_x509_cert_url:
         rootdirectory:
+        chunksize:
       delete:
         enabled: true
       redirect:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ networks:
 volumes:
   elasticsearch_data:
     name: elasticsearch-data
+  model_config:
+    name: model-config
 
 services:
   api_gateway:
@@ -224,7 +226,7 @@ services:
       CFG_SERVER_EDITION: ${EDITION}
       CFG_SERVER_INSTILLCOREHOST: http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT}
       CFG_RAYSERVER_GRPCURI: ${RAY_SERVER_HOST}:${RAY_SERVER_SERVE_GRPC_PORT}
-      CFG_RAYSERVER_MODELSTORE: /model-backend
+      CFG_RAYSERVER_MODELSTORE: /model-config
       CFG_RAYSERVER_VRAM: ${RAY_SERVER_VRAM}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
       CFG_DATABASE_PORT: ${POSTGRESQL_PORT}
@@ -236,6 +238,8 @@ services:
       CFG_CACHE_REDIS_REDISOPTIONS_ADDR: ${REDIS_HOST}:${REDIS_PORT}
       CFG_LOG_EXTERNAL: ${OBSERVE_ENABLED}
       CFG_LOG_OTELCOLLECTOR_PORT: ${OTEL_COLLECTOR_PORT}
+    volumes:
+      - model_config:/model-config
     command:
       - /bin/sh
       - -c
@@ -282,6 +286,8 @@ services:
       CFG_CACHE_REDIS_REDISOPTIONS_ADDR: ${REDIS_HOST}:${REDIS_PORT}
       CFG_LOG_EXTERNAL: ${OBSERVE_ENABLED}
       CFG_LOG_OTELCOLLECTOR_PORT: ${OTEL_COLLECTOR_PORT}
+    volumes:
+      - model_config:/model-config
     entrypoint: ./model-backend-worker
     depends_on:
       temporal:


### PR DESCRIPTION
Because

- deployment config should be preserved even if model-backend pod restart for unknown reasons

This commit

- store deployment config in pvc
