### PR TITLE
chore(model-hub): update sdxl model hardware type

### DIFF
--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -60,7 +60,7 @@
     "visibility": "VISIBILITY_PUBLIC",
     "task": "TASK_TEXT_TO_IMAGE",
     "region": "REGION_GCP_EUROPE_WEST4",
-    "hardware": "NVIDIA_A100",
+    "hardware": "NVIDIA_L4",
     "version": "v0.1.0",
     "configuration": {}
   },


### PR DESCRIPTION
Because

- Stable Diffusion XL can run on `L4` GPU

This commit

- update sdxl model hardware type
