### PR TITLE
chore(artifact): add minio and mgmt in configmap

### DIFF
--- a/charts/core/templates/_helpers.tpl
+++ b/charts/core/templates/_helpers.tpl
@@ -472,3 +472,10 @@ Allow KubeVersion to be overridden.
 {{- define "core.ingress.kubeVersion" -}}
   {{- default .Capabilities.KubeVersion.Version .Values.expose.ingress.kubeVersionOverride -}}
 {{- end -}}
+
+{{/*
+minio
+*/}}
+{{- define "core.minio" -}}
+  {{- printf "%s-minio" (include "core.fullname" .) -}}
+{{- end -}}

--- a/charts/core/templates/artifact-backend/configmap.yaml
+++ b/charts/core/templates/artifact-backend/configmap.yaml
@@ -69,3 +69,9 @@ data:
     registry:
       host: {{ template "core.registry" . }}
       port: {{ template "core.registry.port" . }}
+    minio:
+      host: {{ template "core.minio" . }}
+      port: {{ .Values.artifactBackend.minio.port }}
+      rootuser: {{ .Values.artifactBackend.minio.rootuser }}
+      rootpwd: {{ .Values.artifactBackend.minio.rootpwd }}
+      bucketname: {{ .Values.artifactBackend.minio.bucketname }}

--- a/charts/core/templates/artifact-backend/configmap.yaml
+++ b/charts/core/templates/artifact-backend/configmap.yaml
@@ -75,3 +75,7 @@ data:
       rootuser: {{ .Values.artifactBackend.minio.rootuser }}
       rootpwd: {{ .Values.artifactBackend.minio.rootpwd }}
       bucketname: {{ .Values.artifactBackend.minio.bucketname }}
+    mgmtbackend:
+      host: {{ template "core.mgmtBackend" . }}
+      publicport: {{ template "core.mgmtBackend.publicPort" . }}
+      privateport: {{ template "core.mgmtBackend.privatePort" . }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -600,6 +600,11 @@ artifactBackend:
     spec:
       minAvailable:
       maxUnavailable:
+  minio:
+    port: 9000
+    rootuser: minioadmin
+    rootpwd: minioadmin
+    bucketname: instill-ai-knowledge-bases
 # -- The configuration of console
 console:
   # -- Enable console deployment or not
@@ -1578,4 +1583,4 @@ tags:
   model: true
   observability: true
   prometheusStack: false
-  milvus: false
+  milvus: true


### PR DESCRIPTION
Because

artifact backend needs the connection info of minio

This commit

adds minio-related connection setting
