### PR TITLE
chore(mgmt): update mgmt and pipeline config

### DIFF
--- a/charts/core/templates/mgmt-backend/configmap.yaml
+++ b/charts/core/templates/mgmt-backend/configmap.yaml
@@ -57,7 +57,7 @@ data:
       token: {{ .Values.influxdbCloud.token }}
       org: {{ .Values.influxdbCloud.organization }}
       bucket: {{ .Values.influxdbCloud.bucket }}
-      flushinterval: 10 # In seconds for non-blocking batch mode
+      flushinterval: 10s
       https:
         cert:
         key:

--- a/charts/core/templates/pipeline-backend/configmap.yaml
+++ b/charts/core/templates/pipeline-backend/configmap.yaml
@@ -69,7 +69,7 @@ data:
       token: {{ .Values.influxdbCloud.token }}
       org: {{ .Values.influxdbCloud.organization }}
       bucket: {{ .Values.influxdbCloud.bucket }}
-      flushinterval: 10 # In seconds for non-blocking batch mode
+      flushinterval: 10s
       https:
         cert:
         key:


### PR DESCRIPTION
Because

- Flush interval config param was changed to duration in [`pipeline-backend`](https://github.com/instill-ai/pipeline-backend/pull/508/files#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaR37) and [`mgmt-backend`](https://github.com/instill-ai/mgmt-backend/commit/3d529fac4e407c1de2a94ce83d7b8e947733c24c#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaR43).

This commit

- Updates Helm charts accordingly.
