### PR TITLE
chore(pipeline): bump pipeline migration version

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -388,7 +388,7 @@ pipelineBackend:
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 16
+  dbVersion: 17
   # -- workflow setting
   workflow:
     maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- https://github.com/instill-ai/pipeline-backend/pull/529 introduced a new
  migration.

This commit

- Bumps the pipeline DB version
