### PR TITLE
chore(model): bump model db version

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -473,7 +473,7 @@ modelBackend:
   # -- The path of configuration file for model-backend
   configPath: /model-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 6
+  dbVersion: 7
   instillCoreHost:
   # -- The configuration of Temporal Cloud
   temporal:


### PR DESCRIPTION
Because

- model-backend has a new migration version

This commit

- bump model db version
