### PR TITLE
chore(helm): add instillcloud host setting for pipeline-backend

### DIFF
--- a/charts/core/templates/pipeline-backend/configmap.yaml
+++ b/charts/core/templates/pipeline-backend/configmap.yaml
@@ -98,3 +98,6 @@ data:
         port: 8083
         replicationtimeframe: 1
       {{- end }}
+    instillcloud:
+      host: api.instill.tech
+      port: 443


### PR DESCRIPTION
Because

- In pipeline-backend, we connect to Instill Cloud to download the preset pipelines.

This commit

- Adds the Instill Cloud host setting for pipeline-backend.