### PR TITLE
chore(milvus): add node selector to its deps

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1562,6 +1562,7 @@ milvus:
       accessMode: ReadWriteOnce
       size: 30Gi
     zookeeper:
+      nodeSelector: {}
       enabled: true
       replicaCount: 1
   broker:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1521,15 +1521,21 @@ milvus:
     enabled: false
   mixCoordinator:
     enabled: true
+
+  # https://github.com/zilliztech/milvus-helm/blob/adc5c36dbb417fb259c81535b9b623861fe3f14f/charts/milvus/values.yaml#L485C9-L485C85
+  # ref: https://github.com/zilliztech/milvus-helm/blob/master/charts/minio/README.md
   minio:
     mode: standalone
+    nodeSelector: {}
     replicas: 1
     persistence:
       size: 50Gi
   etcd:
+    nodeSelector: {}
     enabled: true
     replicaCount: 1
   pulsar:
+    nodeSelector: {}
     enabled: false
     bookkeeper:
       replicaCount: 1
@@ -1545,6 +1551,7 @@ milvus:
           memory:
           cpu: 0.5
   kafka:
+    nodeSelector: {}
     enabled: true
     replicaCount: 1
     defaultReplicationFactor: 1


### PR DESCRIPTION
Because

we don't want milvus and its deps consume resource of other service.

This commit

add node selector for its deps
