### PR TITLE
chore(KB): add needed configs for file-to-embedding process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ __pycache__
 
 # Macbook
 .DS_Store
+
+# Helm rendered test templates
+rendered-test-template.yaml

--- a/charts/core/templates/artifact-backend/configmap.yaml
+++ b/charts/core/templates/artifact-backend/configmap.yaml
@@ -79,3 +79,12 @@ data:
       host: {{ template "core.mgmtBackend" . }}
       publicport: {{ template "core.mgmtBackend.publicPort" . }}
       privateport: {{ template "core.mgmtBackend.privatePort" . }}
+    pipelinebackend:
+      host: {{ template "core.pipelineBackend" . }}
+      publicport: {{ template "core.pipelineBackend.publicPort" . }}
+      privateport: {{ template "core.pipelineBackend.privatePort" . }}
+    milvus:
+      host: {{ template "core.milvus" . }}
+      port: {{ template "core.milvus.port" . }}
+    filetoembeddingworker:
+      numberofworkers: {{ .Values.artifactBackend.numberOfWorkers }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -605,6 +605,7 @@ artifactBackend:
     rootuser: minioadmin
     rootpwd: minioadmin
     bucketname: instill-ai-knowledge-bases
+  numberOfWorkers: 20
 # -- The configuration of console
 console:
   # -- Enable console deployment or not


### PR DESCRIPTION
Because

1. artifcat backend needs the necessary config to connect pipeline backend
2. artifact backend uses the number of works in config
3. artifact backend need the necessary config to connect milvus

This commit

add necessary configs in configmap.yaml
