### PR TITLE
chore(helm): add influxdb config in model-backend configmap

### DIFF
--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -108,4 +108,13 @@ data:
     registry:
       host: {{ template "core.registry" . }}
       port: {{ template "core.registry.port" . }}
+    influxdb:
+      url: {{ .Values.influxdbCloud.url }}
+      token: {{ .Values.influxdbCloud.token }}
+      org: {{ .Values.influxdbCloud.organization }}
+      bucket: {{ .Values.influxdbCloud.bucket }}
+      flushinterval: 10s
+      https:
+        cert:
+        key:
 {{- end }}


### PR DESCRIPTION
Because

- Influxdb config is required for model-backend to send metrics

This commit

- add influxdb config in model-backend configmap
