### PR TITLE
fix(core): make value in yaml compatible with strict parser

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -569,7 +569,7 @@ services:
     image: ${MILVUS_IMAGE}:${MILVUS_VERSION}
     restart: unless-stopped
     environment:
-      ETCD_USE_EMBED: true
+      ETCD_USE_EMBED: "true"
       COMMON_STORAGETYPE: local
     command: milvus run standalone 1> /dev/null
     healthcheck:


### PR DESCRIPTION
Because

seems in image build environment using strict(or old) yaml parser for docker compose.

This commit

use string instead of bool
