### PR TITLE
chore(pipeline): use kebab-case in JSON operator

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -388,7 +388,7 @@ pipelineBackend:
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 18
+  dbVersion: 19
   # -- workflow setting
   workflow:
     maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- https://github.com/instill-ai/pipeline-backend/pull/548 migrates recipes to
  use kebab-case in JQ task input fields.

This commit

- Updates the references to the latest migration.
