### PR TITLE
chore(artifact): add version update in helm release

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -83,6 +83,7 @@ jobs:
           yq ".rayService.image.tag=\"$RAY_SERVER_VERSION\"" -i charts/core/values.yaml
           yq ".temporal.image.tag=\"$TEMPORAL_VERSION\"" -i charts/core/values.yaml
           yq ".temporal.admintools.image.tag=\"$TEMPORAL_VERSION\"" -i charts/core/values.yaml
+          yq ".artifactBackend.image.tag=\"$ARTIFACT_BACKEND_VERSION\"" -i charts/core/values.yaml
       - name: Get current chart version
         id: get-current-chart-version
         run: |


### PR DESCRIPTION
Because

the artifact backend image used in helm install is out of date.

This commit

upgrade the version for helm ce user
