### PR TITLE
chore(helm): disable observability by default

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1592,6 +1592,6 @@ milvus:
         namespace: instill-ai
 tags:
   model: true
-  observability: true
+  observability: false
   prometheusStack: false
   milvus: true


### PR DESCRIPTION
Because

- observability stack can be resource intensive

This commit

- set `observability` flag to false by default
