### PR TITLE
chore(openfga): set port on machine

### DIFF
--- a/.env
+++ b/.env
@@ -143,6 +143,7 @@ INFLUXDB_PORT=8086
 OPENFGA_IMAGE=openfga/openfga
 OPENFGA_VERSION=v1.5.1
 OPENFGA_HOST=openfga
+OPENFGA_PORT=18081
 
 # otel
 OTEL_COLLECTOR_IMAGE=otel/opentelemetry-collector-contrib

--- a/docker-compose-latest.yml
+++ b/docker-compose-latest.yml
@@ -171,7 +171,9 @@ services:
     ports:
       - ${MILVUS_PORT}:19530
     command: milvus run standalone
-
+  openfga:
+    ports:
+      - ${OPENFGA_PORT}:8081
   minio:
     ports:
       - ${MINIO_EXTERNAL_PORT}:${MINIO_PORT}


### PR DESCRIPTION
Because

sometime we need to connect to openfga directly

This commit

expose its port on machine
