### PR TITLE
feat(registry): support s3 as storage backend

### DIFF
--- a/charts/core/templates/registry/configmap.yaml
+++ b/charts/core/templates/registry/configmap.yaml
@@ -15,6 +15,9 @@ data:
       {{- if eq .Values.registry.config.storage.type "gcs" }}
       gcs:
         {{- toYaml .Values.registry.config.storage.gcs | nindent 8 }}
+      {{- else if eq .Values.registry.config.storage.type "s3" }}
+      s3:
+        {{- toYaml .Values.registry.config.storage.s3 | nindent 8 }}
       {{- else }}
       filesystem:
         {{- toYaml .Values.registry.config.storage.filesystem | nindent 8 }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1445,6 +1445,29 @@ registry:
           client_x509_cert_url:
         rootdirectory:
         chunksize:
+      s3:
+        accesskey:
+        secretkey:
+        region:
+        regionendpoint:
+        forcepathstyle:
+        accelerate:
+        bucket:
+        encrypt:
+        keyid:
+        secure:
+        skipverify:
+        v4auth:
+        chunksize:
+        storageclass:
+        multipartcopychunksize:
+        multipartcopymaxconcurrency:
+        multipartcopythresholdsize:
+        rootdirectory:
+        usedualstack:
+        useragent:
+        objectacl:
+        loglevel: debug
       delete:
         enabled: true
       redirect:


### PR DESCRIPTION
Because

- We would like to support `s3` as registry storage backend

This commit

- add `s3` in registry config
