### PR TITLE
chore(helm): add image-pull-secret tag for each service separately

### DIFF
--- a/charts/core/templates/api-gateway/deployment.yaml
+++ b/charts/core/templates/api-gateway/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       {{- end }}
       automountServiceAccountToken: {{ .Values.console.automountServiceAccountToken | default false }}
       terminationGracePeriodSeconds: 120
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.apiGateway.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/core/templates/artifact-backend/deployment.yaml
+++ b/charts/core/templates/artifact-backend/deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       automountServiceAccountToken: {{ .Values.artifactBackend.automountServiceAccountToken | default false }}
       terminationGracePeriodSeconds: 120
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.artifactBackend.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/core/templates/mgmt-backend/deployment.yaml
+++ b/charts/core/templates/mgmt-backend/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       automountServiceAccountToken: {{ .Values.mgmtBackend.automountServiceAccountToken | default false }}
       terminationGracePeriodSeconds: 120
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.mgmtBackend.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/core/templates/model-backend/deployment.yaml
+++ b/charts/core/templates/model-backend/deployment.yaml
@@ -44,12 +44,12 @@ spec:
       securityContext:
         runAsUser: 65534
         runAsGroup: 65534
-      {{- if .Values.modelBackend.serviceAccountName }}
-      serviceAccountName: {{ .Values.modelBackend.serviceAccountName }}
-      {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.modelBackend.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.modelBackend.serviceAccountName }}
+      serviceAccountName: {{ .Values.modelBackend.serviceAccountName }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.modelBackend.automountServiceAccountToken | default false }}
       terminationGracePeriodSeconds: 120

--- a/charts/core/templates/model-backend/post-install-job.yaml
+++ b/charts/core/templates/model-backend/post-install-job.yaml
@@ -29,7 +29,7 @@ spec:
       {{- if .Values.modelBackend.serviceAccountName }}
       serviceAccountName: {{ .Values.modelBackend.serviceAccountName }}
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.modelBackend.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/core/templates/pipeline-backend/deployment.yaml
+++ b/charts/core/templates/pipeline-backend/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       {{- end }}
       automountServiceAccountToken: {{ .Values.pipelineBackend.automountServiceAccountToken | default false }}
       terminationGracePeriodSeconds: 120
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.pipelineBackend.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/core/templates/ray-service/ray-service.yaml
+++ b/charts/core/templates/ray-service/ray-service.yaml
@@ -27,7 +27,11 @@ spec:
       num-gpus: "0"
       disable-usage-stats: "true"
     template:
-      spec:
+      spec:  
+        {{- with .Values.rayService.headGroupSpec.imagePullSecrets }}
+        imagePullSecrets:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- with .Values.rayService.headGroupSpec.nodeSelector }}
         nodeSelector:
           {{- toYaml . | nindent 10 }}
@@ -131,6 +135,10 @@ spec:
       # pod template
       template:
         spec:
+          {{- with $workerGroupSpecs.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with $workerGroupSpecs.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -243,6 +243,7 @@ usage:
   port: 443
 # -- The configuration of api-gateway
 apiGateway:
+  imagePullSecrets:
   # -- The image of api-gateway
   image:
     repository: instill/api-gateway
@@ -300,6 +301,7 @@ apiGateway:
       maxUnavailable:
 # -- The configuration of mgmt-backend
 mgmtBackend:
+  imagePullSecrets:
   # -- The image of mgmt-backend
   image:
     repository: instill/mgmt-backend
@@ -372,6 +374,7 @@ mgmtBackend:
     serverName:
 # -- The configuration of pipeline-backend
 pipelineBackend:
+  imagePullSecrets:
   # -- The image of pipeline-backend
   image:
     repository: instill/pipeline-backend
@@ -457,6 +460,7 @@ pipelineBackend:
   modelBackendPortOverride:
 # -- The configuration of model-backend
 modelBackend:
+  imagePullSecrets:
   # -- The image of model-backend
   image:
     repository: instill/model-backend
@@ -542,6 +546,7 @@ modelBackend:
 artifactBackend:
   # -- Enable artifact-backend deployment
   enabled: true
+  imagePullSecrets:
   # -- The image of artifact-backend
   image:
     repository: instill/artifact-backend
@@ -690,6 +695,7 @@ rayService:
     tag: 0.4.0-alpha
     pullPolicy: IfNotPresent
   headGroupSpec:
+    imagePullSecrets:
     resources:
       limits:
         cpu: "1"
@@ -706,6 +712,7 @@ rayService:
       minReplicas: 1
       maxReplicas: 1
       groupName: "cpu-group"
+      imagePullSecrets:
       gpuWorkerGroup:
         enabled: false
         # https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml#L39


### PR DESCRIPTION
Because

- We need to add the `image-pull-secret` tag for each service separately as it is used to deploy `instill-core` over `aws`.

This commit

- add image-pull-secret tag for each service separately
