### PR TITLE
chore(helm): bump model db version

### DIFF
--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -68,6 +68,8 @@ data:
       {{- end }}
       name: model
       version: {{ .Values.modelBackend.dbVersion }}
+      cloudversion: {{ .Values.modelBackend.dbCloudVersion }}
+      cloudmigrationtable: cloud_schema_migrations
       timezone: Etc/UTC
       pool:
         idleconnections: {{ .Values.database.maxIdleConns }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -474,7 +474,7 @@ modelBackend:
   # -- The path of configuration file for model-backend
   configPath: /model-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 7
+  dbVersion: 8
   instillCoreHost:
   # -- The configuration of Temporal Cloud
   temporal:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -475,6 +475,7 @@ modelBackend:
   configPath: /model-backend/config/config.yaml
   # -- The database migration version
   dbVersion: 8
+  dbCloudVersion:
   instillCoreHost:
   # -- The configuration of Temporal Cloud
   temporal:


### PR DESCRIPTION
Because

- `model-backend` has been updated to `8`

This commit

- bump model db version
