### PR TITLE
fix(helm): fix pipeline pod permission

### DIFF
--- a/charts/core/templates/pipeline-backend/deployment.yaml
+++ b/charts/core/templates/pipeline-backend/deployment.yaml
@@ -38,10 +38,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      # Distroless nonroot:nonroot is 65532:65532
       securityContext:
-        runAsUser: 65532
-        runAsGroup: 65532
+        runAsUser: 65534
+        runAsGroup: 65534
       {{- if .Values.pipelineBackend.serviceAccountName }}
       serviceAccountName: {{ .Values.pipelineBackend.serviceAccountName }}
       {{- end }}


### PR DESCRIPTION
Because

- The pipeline pod security settings are incorrect.

This commit

- Fixes the pipeline pod permissions.