### PR TITLE
feat(minIO): change distributed mode

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1548,7 +1548,7 @@ milvus:
   # https://github.com/zilliztech/milvus-helm/blob/adc5c36dbb417fb259c81535b9b623861fe3f14f/charts/milvus/values.yaml#L485C9-L485C85
   # ref: https://github.com/zilliztech/milvus-helm/blob/master/charts/minio/README.md
   minio:
-    mode: standalone
+    mode: distributed
     nodeSelector: {}
     replicas: 1
     persistence:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1550,7 +1550,7 @@ milvus:
   minio:
     mode: distributed
     nodeSelector: {}
-    replicas: 1
+    replicas: 2
     persistence:
       size: 50Gi
   etcd:


### PR DESCRIPTION
Because

we might need to scale minIO up in the future.

This commit

make minIO in distributed mode
