### PR TITLE
chore(pipeline): apply environment variables on migration command

### DIFF
--- a/charts/core/templates/pipeline-backend/deployment.yaml
+++ b/charts/core/templates/pipeline-backend/deployment.yaml
@@ -90,6 +90,10 @@ spec:
             - name: config
               mountPath: {{ .Values.pipelineBackend.configPath }}
               subPath: config.yaml
+          env:
+          {{- if .Values.pipelineBackend.extraEnv }}
+            {{- toYaml .Values.pipelineBackend.extraEnv | nindent 12 }}
+          {{- end }}
         - name: pipeline-backend-init
           image: {{ .Values.pipelineBackend.image.repository }}:{{ .Values.pipelineBackend.image.tag }}
           imagePullPolicy: {{ .Values.pipelineBackend.image.pullPolicy }}


### PR DESCRIPTION
Because

- We want to pass env variables to the migration command to perform extra migrations in cloud-only environments.

This commit

- Reads the environment values defined in the Helm charts
