### PR TITLE
ci(Makefile): fix make all/latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,14 +77,14 @@ endif
 
 .PHONY: build-latest
 build-latest:				## Build latest images for all Instill Core components
-	@docker build --progress plain \
-		--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
-		--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
-		--build-arg K6_VERSION=${K6_VERSION} \
-		--build-arg CACHE_DATE="$(shell date)" \
-		--target latest \
-		-t ${INSTILL_CORE_IMAGE_NAME}:latest .
 	@if [ "${BUILD}" = "true" ]; then \
+		docker build --progress plain \
+			--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
+			--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
+			--build-arg K6_VERSION=${K6_VERSION} \
+			--build-arg CACHE_DATE="$(shell date)" \
+			--target latest \
+			-t ${INSTILL_CORE_IMAGE_NAME}:latest .; \
 		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v ./.env:/instill-core/.env \
@@ -103,7 +103,8 @@ build-latest:				## Build latest images for all Instill Core components
 
 .PHONY: build-release
 build-release:				## Build release images for all Instill Core components
-	@docker build --progress plain \
+	@if [ "${BUILD}" = "true" ]; then \
+		docker build --progress plain \
 			--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
 			--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
 			--build-arg K6_VERSION=${K6_VERSION} \
@@ -115,8 +116,7 @@ build-release:				## Build release images for all Instill Core components
 			--build-arg ARTIFACT_BACKEND_VERSION=${ARTIFACT_BACKEND_VERSION} \
 			--build-arg CONSOLE_VERSION=${CONSOLE_VERSION} \
 			--target release \
-			-t ${INSTILL_CORE_IMAGE_NAME}:${INSTILL_CORE_VERSION} .
-	@if [ "${BUILD}" = "true" ]; then \
+			-t ${INSTILL_CORE_IMAGE_NAME}:${INSTILL_CORE_VERSION} .; \
 		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v ./.env:/instill-core/.env \


### PR DESCRIPTION
Because

- `make all` and `make latest` should not build the docker-in-docker image by default

This commit

- fix the Makefile targets
