### PR TITLE
chore(milvus): adjust milvus's log level

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1527,7 +1527,7 @@ milvus:
   tolerations: []
   affinity: {}
   log:
-    level: "info"
+    level: "error"
     file:
       maxSize: 10 # MB
       maxAge: 12 # day


### PR DESCRIPTION
Because

log amount is too much

This commit

change the log level to error

NOTE: we may chang back when it is necessary.
