### PR TITLE
chore(helm): sets up Artifact component infra

### DIFF
--- a/charts/core/templates/pipeline-backend/configmap.yaml
+++ b/charts/core/templates/pipeline-backend/configmap.yaml
@@ -37,6 +37,14 @@ data:
         cert: /etc/instill-ai/vdp/ssl/mgmt/tls.crt
         key: /etc/instill-ai/vdp/ssl/mgmt/tls.key
       {{- end }}
+    artifactbackend:
+      host: {{ default (include "core.artifactBackend" . ) .Values.pipelineBackend.artifactBackendHostOverride }}
+      publicport: {{ default (include "core.artifactBackend.publicPort" . ) .Values.pipelineBackend.artifactBackendPortOverride }}
+      {{- if .Values.internalTLS.enabled }}
+      https:
+        cert: /etc/instill-ai/vdp/ssl/artifact/tls.crt
+        key: /etc/instill-ai/vdp/ssl/artifact/tls.key
+      {{- end }}
     modelbackend:
       host: {{ default (include "core.modelBackend" . ) .Values.pipelineBackend.modelBackendHostOverride }}
       publicport: {{ default (include "core.modelBackend.publicPort" . ) .Values.pipelineBackend.modelBackendPortOverride }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -455,6 +455,8 @@ pipelineBackend:
       maxUnavailable:
   modelBackendHostOverride:
   modelBackendPortOverride:
+  artifactBackendHostOverride:
+  artifactBackendPortOverride:
 # -- The configuration of model-backend
 modelBackend:
   # -- The image of model-backend


### PR DESCRIPTION
Because

- We need to configure connection settings for the Artifact component.

This commit

- Sets up the infrastructure for the Artifact component.
