### PR TITLE
chore(ray): disable periodic autoscaler status logging

### DIFF
--- a/charts/core/templates/ray-service/ray-service.yaml
+++ b/charts/core/templates/ray-service/ray-service.yaml
@@ -15,7 +15,9 @@ spec:
     idleTimeoutSeconds: 60
     imagePullPolicy: {{ $.Values.rayService.image.pullPolicy }}
     securityContext: {}
-    env: []
+    env:
+      - name: RAY_ENABLE_CLUSTER_STATUS_LOG
+        value: "0"
     envFrom: []
     {{- if .Values.rayService.spec.autoscalerOptions.resources }}
     resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -433,6 +433,7 @@ services:
       - RAY_GRAFANA_HOST=http://${GRAFANA_HOST}:${GRAFANA_PORT}
       - RAY_PROMETHEUS_HOST=http://${PROMETHEUS_HOST}:${PROMETHEUS_PORT}
       - RAY_GRAFANA_IFRAME_HOST=http://localhost:${GRAFANA_PORT}
+      - RAY_ENABLE_CLUSTER_STATUS_LOG=0
       - RAY_worker_register_timeout_seconds=3600
     entrypoint: ["/bin/bash", "-c"]
     command: |


### PR DESCRIPTION
Because

- RayCluster autoscaler is emitting lengthy unnecessary logs

This commit

- disable periodic autoscaler status logging
