### PR TITLE
chore(model): sets up minio for model-backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ __pycache__
 
 # Helm rendered test templates
 rendered-test-template.yaml
+.idea

--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -119,4 +119,11 @@ data:
       https:
         cert:
         key:
+    minio:
+      host: {{ template "core.minio" . }}
+      port: {{ .Values.modelBackend.minio.port }}
+      rootuser: {{ .Values.modelBackend.minio.rootuser }}
+      rootpwd: {{ .Values.modelBackend.minio.rootpwd }}
+      bucketname: {{ .Values.modelBackend.minio.bucketname }}
+      secure: {{ .Values.modelBackend.minio.secure }}
 {{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -541,6 +541,12 @@ modelBackend:
     spec:
       minAvailable:
       maxUnavailable:
+  minio:
+    port: 9000
+    rootuser: minioadmin
+    rootpwd: minioadmin
+    bucketname: instill-ai-model
+    secure: true
 # -- The configuration of artifact-backend
 artifactBackend:
   # -- Enable artifact-backend deployment

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -546,7 +546,7 @@ modelBackend:
     rootuser: minioadmin
     rootpwd: minioadmin
     bucketname: instill-ai-model
-    secure: true
+    secure: false
 # -- The configuration of artifact-backend
 artifactBackend:
   # -- Enable artifact-backend deployment


### PR DESCRIPTION
related to https://github.com/instill-ai/model-backend/pull/651

Because

- model backend needs to store data in mino

This commit

- added config for minio in model-backend
