### PR TITLE
chore(model_hub): update llava model version

### DIFF
--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -47,8 +47,8 @@
     "visibility": "VISIBILITY_PUBLIC",
     "task": "TASK_VISUAL_QUESTION_ANSWERING",
     "region": "REGION_GCP_EUROPE_WEST4",
-    "hardware": "NVIDIA_A100",
-    "version": "v0.1.0",
+    "hardware": "NVIDIA_L4",
+    "version": "v0.1.1",
     "configuration": {}
   },
   {


### PR DESCRIPTION
Because

- Due to availability problem of `A100` on GCP, we are going to switch hardware type of `llava` model to `L4` GPU
- update llava version to support weights offloading

This commit

- update llava model version and hardware type
