### PR TITLE
chore(vdp):update db version

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -388,7 +388,7 @@ pipelineBackend:
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 22
+  dbVersion: 23
   # -- workflow setting
   workflow:
     maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- we update text component fields

This commit

- update db version for migration