### PR TITLE
chore(helm): add minio setting for pipeline-backend

### DIFF
--- a/charts/core/templates/pipeline-backend/configmap.yaml
+++ b/charts/core/templates/pipeline-backend/configmap.yaml
@@ -110,3 +110,10 @@ data:
     instillcloud:
       host: api.instill.tech
       port: 443
+    minio:
+      host: {{ template "core.minio" . }}
+      port: {{ .Values.pipelineBackend.minio.port }}
+      rootuser: {{ .Values.pipelineBackend.minio.rootuser }}
+      rootpwd: {{ .Values.pipelineBackend.minio.rootpwd }}
+      bucketname: {{ .Values.pipelineBackend.minio.bucketname }}
+      secure: {{ .Values.pipelineBackend.minio.secure }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -388,7 +388,7 @@ pipelineBackend:
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 22
+  dbVersion: 23
   # -- workflow setting
   workflow:
     maxWorkflowTimeout: 3600 # in seconds

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -457,6 +457,12 @@ pipelineBackend:
   modelBackendPortOverride:
   artifactBackendHostOverride:
   artifactBackendPortOverride:
+  minio:
+    port: 9000
+    rootuser: minioadmin
+    rootpwd: minioadmin
+    bucketname: instill-ai-vdp
+    secure: false
 # -- The configuration of model-backend
 modelBackend:
   # -- The image of model-backend


### PR DESCRIPTION
Because

- The minio setting is missing.

This commit

- Adds minio setting for pipeline-backend.
