### PR TITLE
chore(charts): remove host/port override for model and artifact backend

### DIFF
--- a/charts/core/templates/pipeline-backend/configmap.yaml
+++ b/charts/core/templates/pipeline-backend/configmap.yaml
@@ -38,16 +38,16 @@ data:
         key: /etc/instill-ai/vdp/ssl/mgmt/tls.key
       {{- end }}
     artifactbackend:
-      host: {{ default (include "core.artifactBackend" . ) .Values.pipelineBackend.artifactBackendHostOverride }}
-      publicport: {{ default (include "core.artifactBackend.publicPort" . ) .Values.pipelineBackend.artifactBackendPortOverride }}
+      host: {{ template "core.artifactBackend" . }}
+      publicport: {{ template "core.artifactBackend.publicPort" . }}
       {{- if .Values.internalTLS.enabled }}
       https:
         cert: /etc/instill-ai/vdp/ssl/artifact/tls.crt
         key: /etc/instill-ai/vdp/ssl/artifact/tls.key
       {{- end }}
     modelbackend:
-      host: {{ default (include "core.modelBackend" . ) .Values.pipelineBackend.modelBackendHostOverride }}
-      publicport: {{ default (include "core.modelBackend.publicPort" . ) .Values.pipelineBackend.modelBackendPortOverride }}
+      host: {{ template "core.modelBackend" . }}
+      publicport: {{ template "core.modelBackend.publicPort" . }}
       {{- if .Values.internalTLS.enabled }}
       https:
         cert: /etc/instill-ai/vdp/ssl/model/tls.crt

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -453,10 +453,6 @@ pipelineBackend:
     spec:
       minAvailable:
       maxUnavailable:
-  modelBackendHostOverride:
-  modelBackendPortOverride:
-  artifactBackendHostOverride:
-  artifactBackendPortOverride:
   minio:
     port: 9000
     rootuser: minioadmin


### PR DESCRIPTION
Because

- The host/port override for the model and artifact backends is no longer needed.

This commit

- Removes the host/port override for the model and artifact backends.