### PR TITLE
chore(pipeline): bump db version

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -388,7 +388,7 @@ pipelineBackend:
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 24
+  dbVersion: 26
   # -- workflow setting
   workflow:
     maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- Integration feature modifies the `pipeline` database.

This commit

- Bump database version.
