### PR TITLE
ci(workflows): refactor integration tests

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -11,13 +11,11 @@ on:
         type: string
 
 jobs:
-  helm-integration-test-latest-linux:
-    if: inputs.target == 'latest'
+  helm-integration-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
-      # mono occupies port 8084 which conflicts with mgmt-backend
-      - name: Stop mono service
+      - name: Setup environment
         run: |
           sudo kill -9 `sudo lsof -t -i:8084`
           sudo lsof -i -P -n | grep LISTEN
@@ -29,13 +27,12 @@ jobs:
           remove-dotnet: "true"
           build-mount-path: "/var/lib/docker/"
 
-      - name: Restart docker
-        run: sudo service docker restart
+      - name: Setup Minikube
+        run: |
+          sudo service docker restart
+          minikube start --cpus 4 --memory 10485
 
-      - name: Start Minikube
-        run: minikube start --cpus 4 --memory 10485
-
-      - name: Checkout repo
+      - name: Checkout repo and load .env
         uses: actions/checkout@v3
         with:
           repository: instill-ai/instill-core
@@ -49,156 +46,68 @@ jobs:
         run: |
           curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
 
-      - name: Build Instill Core (latest)
+      - name: Launch Helm Instill Core (${{ inputs.target }})
         run: |
-          make build-latest BUILD=true
-
-      - name: Launch Helm Instill Core (latest)
-        run: |
-          helm install core charts/core --namespace instill-ai --create-namespace \
-            --set edition=k8s-ce:test \
-            --set artifactBackend.image.tag=latest \
-            --set apiGateway.image.tag=latest \
-            --set mgmtBackend.image.tag=latest \
-            --set mgmtBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-            --set pipelineBackend.image.tag=latest \
-            --set pipelineBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-            --set modelBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-            --set modelBackend.image.tag=latest \
-            --set console.image.tag=latest \
-            --set rayService.image.tag=latest \
-            --set rayService.headGroupSpec.resources.limits.cpu=0 \
-            --set rayService.headGroupSpec.resources.limits.memory=2Gi \
-            --set rayService.headGroupSpec.resources.requests.cpu=0 \
-            --set rayService.headGroupSpec.resources.requests.memory=2Gi \
-            --set rayService.workerGroupSpecs[0].replicas=1 \
-            --set rayService.workerGroupSpecs[0].minReplicas=1 \
-            --set rayService.workerGroupSpecs[0].maxReplicas=1 \
-            --set rayService.workerGroupSpecs[0].groupName=test-group \
-            --set rayService.workerGroupSpecs[0].gpuWorkerGroup.enabled=false \
-            --set rayService.workerGroupSpecs[0].resources.limits.cpu=1 \
-            --set rayService.workerGroupSpecs[0].resources.limits.memory=2Gi \
-            --set rayService.workerGroupSpecs[0].resources.requests.cpu=1 \
-            --set rayService.workerGroupSpecs[0].resources.requests.memory=2Gi \
-            --set milvus.broker.resources.requests.cpu=0.25 \
-            --set milvus.autorecovery.resources.requests.cpu=0.25 \
-            --set milvus.proxy.resources.requests.cpu=0.25 \
-            --set tags.observability=false \
-            --set tags.prometheusStack=false
-
-      - name: Wait for all pods up
-        run: |
-          while [[ $(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=core" -o 'jsonpath={..status.phase}') != *"Running"* ]]; do
-            echo "$(kubectl get pods --namespace instill-ai)"
-            sleep 10
-          done
-          while [[ $(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=model-backend,app.kubernetes.io/instance=core" -o 'jsonpath={..status.phase}') != *"Running"* ]]; do
-            echo "$(kubectl get pods --namespace instill-ai)"
-          sleep 10
-          done
-          echo "$(kubectl get pods --namespace instill-ai)"
-
-      - name: Port-forward of api-gateway
-        run: |
-          API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=core" -o json | jq -r '.items[0].metadata.name')
-          kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
-          while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
-
-      - name: Run ${{ inputs.component }} integration test (latest)
-        if: inputs.target == 'latest'
-        run: |
-          git clone https://github.com/instill-ai/${{ inputs.component }}.git
-          cd ${{ inputs.component }}
-          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
-
-  helm-integration-test-latest-mac:
-    if: false
-    # disable the mac test temporary
-    # if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
-    runs-on: [self-hosted, macOS, vdp]
-    timeout-minutes: 60
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
-
-      - name: Set up environment
-        run: |
-          brew install make
-
-  helm-integration-test-release-linux:
-    if: inputs.target == 'release'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      # mono occupies port 8084 which conflicts with mgmt-backend
-      - name: Stop mono service
-        run: |
-          sudo kill -9 `sudo lsof -t -i:8084`
-          sudo lsof -i -P -n | grep LISTEN
-
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          overprovision-lvm: "true"
-          remove-dotnet: "true"
-          build-mount-path: "/var/lib/docker/"
-
-      - name: Restart docker
-        run: sudo service docker restart
-
-      - name: Start Minikube
-        run: minikube start --cpus 4 --memory 10485
-
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/instill-core
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Install k6
-        run: |
-          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
-
-      - name: Build Instill Core (latest)
-        run: |
-          make build-latest BUILD=true
-
-      - name: Launch Helm Instill Core (release)
-        run: |
-          helm install core charts/core --namespace instill-ai --create-namespace \
-            --set edition=k8s-ce:test \
-            --set artifactBackend.image.tag=${ARTIFACT_BACKEND_VERSION} \
-            --set apiGateway.image.tag=${API_GATEWAY_VERSION} \
-            --set mgmtBackend.image.tag=${MGMT_BACKEND_VERSION} \
-            --set mgmtBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-            --set pipelineBackend.image.tag=${PIPELINE_BACKEND_VERSION} \
-            --set pipelineBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-            --set modelBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-            --set modelBackend.image.tag=${MODEL_BACKEND_VERSION} \
-            --set console.image.tag=${CONSOLE_VERSION} \
-            --set rayService.image.tag=${RAY_SERVER_VERSION} \
-            --set rayService.headGroupSpec.resources.limits.cpu=0 \
-            --set rayService.headGroupSpec.resources.limits.memory=2Gi \
-            --set rayService.headGroupSpec.resources.requests.cpu=0 \
-            --set rayService.headGroupSpec.resources.requests.memory=2Gi \
-            --set rayService.workerGroupSpecs[0].replicas=1 \
-            --set rayService.workerGroupSpecs[0].minReplicas=1 \
-            --set rayService.workerGroupSpecs[0].maxReplicas=1 \
-            --set rayService.workerGroupSpecs[0].groupName=test-group \
-            --set rayService.workerGroupSpecs[0].gpuWorkerGroup.enabled=false \
-            --set rayService.workerGroupSpecs[0].resources.limits.cpu=1 \
-            --set rayService.workerGroupSpecs[0].resources.limits.memory=2Gi \
-            --set rayService.workerGroupSpecs[0].resources.requests.cpu=1 \
-            --set rayService.workerGroupSpecs[0].resources.requests.memory=2Gi \
-            --set milvus.broker.resources.requests.cpu=0.25 \
-            --set milvus.autorecovery.resources.requests.cpu=0.25 \
-            --set milvus.proxy.resources.requests.cpu=0.25 \
-            --set tags.observability=false \
-            --set tags.prometheusStack=false
+          if [ "${{ inputs.target }}" == "latest" ]; then
+            helm install core charts/core --namespace instill-ai --create-namespace \
+              --set edition=k8s-ce:test \
+              --set artifactBackend.image.tag=latest \
+              --set apiGateway.image.tag=latest \
+              --set mgmtBackend.image.tag=latest \
+              --set pipelineBackend.image.tag=latest \
+              --set modelBackend.image.tag=latest \
+              --set console.image.tag=latest \
+              --set rayService.image.tag=latest \
+              --set rayService.headGroupSpec.resources.limits.cpu=0 \
+              --set rayService.headGroupSpec.resources.limits.memory=2Gi \
+              --set rayService.headGroupSpec.resources.requests.cpu=0 \
+              --set rayService.headGroupSpec.resources.requests.memory=2Gi \
+              --set rayService.workerGroupSpecs[0].replicas=1 \
+              --set rayService.workerGroupSpecs[0].minReplicas=1 \
+              --set rayService.workerGroupSpecs[0].maxReplicas=1 \
+              --set rayService.workerGroupSpecs[0].groupName=test-group \
+              --set rayService.workerGroupSpecs[0].gpuWorkerGroup.enabled=false \
+              --set rayService.workerGroupSpecs[0].resources.limits.cpu=1 \
+              --set rayService.workerGroupSpecs[0].resources.limits.memory=2Gi \
+              --set rayService.workerGroupSpecs[0].resources.requests.cpu=1 \
+              --set rayService.workerGroupSpecs[0].resources.requests.memory=2Gi \
+              --set milvus.broker.resources.requests.cpu=0.25 \
+              --set milvus.autorecovery.resources.requests.cpu=0.25 \
+              --set milvus.proxy.resources.requests.cpu=0.25 \
+              --set tags.observability=false \
+              --set tags.prometheusStack=false
+          else
+            helm install core charts/core --namespace instill-ai --create-namespace \
+              --set edition=k8s-ce:test \
+              --set artifactBackend.image.tag=${ARTIFACT_BACKEND_VERSION} \
+              --set apiGateway.image.tag=${API_GATEWAY_VERSION} \
+              --set mgmtBackend.image.tag=${MGMT_BACKEND_VERSION} \
+              --set mgmtBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
+              --set pipelineBackend.image.tag=${PIPELINE_BACKEND_VERSION} \
+              --set pipelineBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
+              --set modelBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
+              --set modelBackend.image.tag=${MODEL_BACKEND_VERSION} \
+              --set console.image.tag=${CONSOLE_VERSION} \
+              --set rayService.image.tag=${RAY_SERVER_VERSION} \
+              --set rayService.headGroupSpec.resources.limits.cpu=0 \
+              --set rayService.headGroupSpec.resources.limits.memory=2Gi \
+              --set rayService.headGroupSpec.resources.requests.cpu=0 \
+              --set rayService.headGroupSpec.resources.requests.memory=2Gi \
+              --set rayService.workerGroupSpecs[0].replicas=1 \
+              --set rayService.workerGroupSpecs[0].minReplicas=1 \
+              --set rayService.workerGroupSpecs[0].maxReplicas=1 \
+              --set rayService.workerGroupSpecs[0].groupName=test-group \
+              --set rayService.workerGroupSpecs[0].gpuWorkerGroup.enabled=false \
+              --set rayService.workerGroupSpecs[0].resources.limits.cpu=1 \
+              --set rayService.workerGroupSpecs[0].resources.limits.memory=2Gi \
+              --set rayService.workerGroupSpecs[0].resources.requests.cpu=1 \
+              --set rayService.workerGroupSpecs[0].resources.requests.memory=2Gi \
+              --set milvus.broker.resources.requests.cpu=0.25 \
+              --set milvus.autorecovery.resources.requests.cpu=0.25 \
+              --set milvus.proxy.resources.requests.cpu=0.25 \
+              --set tags.observability=false \
+              --set tags.prometheusStack=false
+          fi
 
       - name: Wait for all pods up
         run: |
@@ -218,29 +127,14 @@ jobs:
           kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
           while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
 
-      - name: Uppercase component name
-        id: uppercase
-        run: |
-          echo "COMPONENT_NAME=$(echo ${{ inputs.component }} | tr 'a-z-' 'A-Z_')" >> $GITHUB_OUTPUT
-
-      - name: Run ${{ inputs.component }} integration test (release)
+      - name: Run ${{ inputs.component }} integration test (${{ inputs.target }})
         env:
           COMPONENT_VERSION: ${{ env[format('{0}_VERSION', steps.uppercase.outputs.COMPONENT_NAME)] }}
         run: |
-          git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
+          if [ "${{ inputs.target }}" == "latest" ]; then
+            git clone https://github.com/instill-ai/${{ inputs.component }}.git
+          else
+            git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
+          fi
           cd ${{ inputs.component }}
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
-
-  helm-integration-test-release-mac:
-    if: false
-    # disable the mac test temporary
-    # if: inputs.target == 'release'
-    runs-on: [self-hosted, macOS, vdp]
-    timeout-minutes: 60
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
-
-      - name: Set up environment
-        run: |
-          brew install make

--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -42,9 +42,14 @@ jobs:
         with:
           envFile: .env
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+
       - name: Install k6
         run: |
-          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
+          go install go.k6.io/xk6/cmd/xk6@v${{ env.XK6_VERSION }}
+          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql && sudo cp k6 /usr/bin
 
       - name: Launch Helm Instill Core (${{ inputs.target }})
         run: |

--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -130,6 +130,8 @@ jobs:
         run: |
           API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=core" -o json | jq -r '.items[0].metadata.name')
           kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
+          DATABASE_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=database,app.kubernetes.io/instance=core" -o json | jq -r '.items[0].metadata.name')
+          kubectl --namespace instill-ai port-forward ${DATABASE_POD_NAME} ${POSTGRESQL_PORT}:${POSTGRESQL_PORT} > /dev/null 2>&1 &
           while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
 
       - name: Run ${{ inputs.component }} integration test (${{ inputs.target }})
@@ -142,4 +144,4 @@ jobs:
             git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
           fi
           cd ${{ inputs.component }}
-          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
+          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT} DB_HOST=localhost

--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -33,7 +33,7 @@ jobs:
           minikube start --cpus 4 --memory 10485
 
       - name: Checkout repo and load .env
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: instill-ai/instill-core
 

--- a/.github/workflows/helm-integration-test-console.yml
+++ b/.github/workflows/helm-integration-test-console.yml
@@ -8,13 +8,11 @@ on:
         type: string
 
 jobs:
-  helm-integration-test-latest-linux:
-    if: inputs.target == 'latest'
+  helm-integration-test-console:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
-      # mono occupies port 8084 which conflicts with mgmt-backend
-      - name: Stop mono service
+      - name: Setup environment
         run: |
           sudo kill -9 `sudo lsof -t -i:8084`
           sudo lsof -i -P -n | grep LISTEN
@@ -26,13 +24,12 @@ jobs:
           remove-dotnet: "true"
           build-mount-path: "/var/lib/docker/"
 
-      - name: Restart docker
-        run: sudo service docker restart
+      - name: Setup Minikube
+        run: |
+          sudo service docker restart
+          minikube start --cpus 4 --memory 10485
 
-      - name: Start Minikube
-        run: minikube start --cpus 4 --memory 10485
-
-      - name: Checkout repo
+      - name: Checkout repo and load .env
         uses: actions/checkout@v3
         with:
           repository: instill-ai/instill-core
@@ -42,175 +39,68 @@ jobs:
         with:
           envFile: .env
 
-      - name: Launch Helm Instill Core (latest)
+      - name: Launch Helm Instill Core (${{ inputs.target }})
         run: |
-          helm install core charts/core --namespace instill-ai --create-namespace \
-            --set edition=k8s-ce:test \
-            --set artifactBackend.image.tag=latest \
-            --set apiGateway.image.tag=latest \
-            --set mgmtBackend.image.tag=latest \
-            --set mgmtBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-            --set pipelineBackend.image.tag=latest \
-            --set pipelineBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-            --set modelBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-            --set modelBackend.image.tag=latest \
-            --set console.image.tag=latest \
-            --set rayService.image.tag=latest \
-            --set rayService.headGroupSpec.resources.limits.cpu=0 \
-            --set rayService.headGroupSpec.resources.limits.memory=2Gi \
-            --set rayService.headGroupSpec.resources.requests.cpu=0 \
-            --set rayService.headGroupSpec.resources.requests.memory=2Gi \
-            --set rayService.workerGroupSpecs[0].replicas=1 \
-            --set rayService.workerGroupSpecs[0].minReplicas=1 \
-            --set rayService.workerGroupSpecs[0].maxReplicas=1 \
-            --set rayService.workerGroupSpecs[0].groupName=test-group \
-            --set rayService.workerGroupSpecs[0].gpuWorkerGroup.enabled=false \
-            --set rayService.workerGroupSpecs[0].resources.limits.cpu=1 \
-            --set rayService.workerGroupSpecs[0].resources.limits.memory=2Gi \
-            --set rayService.workerGroupSpecs[0].resources.requests.cpu=1 \
-            --set rayService.workerGroupSpecs[0].resources.requests.memory=2Gi \
-            --set milvus.broker.resources.requests.cpu=0.25 \
-            --set milvus.autorecovery.resources.requests.cpu=0.25 \
-            --set milvus.proxy.resources.requests.cpu=0.25 \
-            --set tags.observability=false \
-            --set tags.prometheusStack=false
-
-      - name: Wait for all pods up
-        run: |
-          while [[ $(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=core" -o 'jsonpath={..status.phase}') != *"Running"* ]]; do
-            echo "$(kubectl get pods --namespace instill-ai)"
-            sleep 10
-          done
-          while [[ $(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=model-backend,app.kubernetes.io/instance=core" -o 'jsonpath={..status.phase}') != *"Running"* ]]; do
-            echo "$(kubectl get pods --namespace instill-ai)"
-          sleep 10
-          done
-          echo "$(kubectl get pods --namespace instill-ai)"
-
-      - name: Port-forward of core api-gateway and console
-        run: |
-          API_GATEWAY_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=core" -o json | jq -r '.items[0].metadata.name')
-          kubectl --namespace instill-ai port-forward ${API_GATEWAY_POD_NAME} ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
-          CONSOLE_POD_NAME=$(kubectl get pods --namespace instill-ai -l "app.kubernetes.io/component=console,app.kubernetes.io/instance=core" -o json | jq -r '.items[0].metadata.name')
-          kubectl --namespace instill-ai port-forward ${CONSOLE_POD_NAME} ${CONSOLE_PORT}:${CONSOLE_PORT} > /dev/null 2>&1 &
-          while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
-          while ! nc -vz localhost ${CONSOLE_PORT} > /dev/null 2>&1; do sleep 1; done
-
-      - name: Run console integration test (latest)
-        run: |
-          git clone https://github.com/instill-ai/console.git
-          cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:latest .
-          docker run -t \
-            -e NEXT_PUBLIC_GENERAL_API_VERSION=v1beta \
-            -e NEXT_PUBLIC_MODEL_API_VERSION=v1alpha \
-            -e NEXT_PUBLIC_CONSOLE_EDITION=k8s-ce:test \
-            -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://localhost:${CONSOLE_PORT} \
-            -e NEXT_PUBLIC_API_GATEWAY_URL=http://localhost:${API_GATEWAY_PORT} \
-            -e NEXT_SERVER_API_GATEWAY_URL=http://localhost:${API_GATEWAY_PORT} \
-            -e NEXT_PUBLIC_SELF_SIGNED_CERTIFICATION=false \
-            -e NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user \
-            --network host \
-            --entrypoint ./entrypoint-playwright.sh \
-            --name core-console-integration-test-latest \
-            console-playwright:latest
-
-      - name: Copy the test-result to host
-        if: always()
-        run: docker cp core-console-integration-test-latest:/app/apps/console/test-results ./test-results
-
-      - name: Upload artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: helm-integration-test-latest-linux-test-results
-          path: test-results
-          retention-days: 1
-
-      - name: Stop and remove console playwright
-        run: |
-          docker stop core-console-integration-test-latest
-          docker rm core-console-integration-test-latest
-
-  helm-integration-test-latest-mac:
-    if: false
-    # disable the mac test temporary
-    # if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
-    runs-on: [self-hosted, macOS, core]
-    timeout-minutes: 60
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
-
-      - name: Set up environment
-        run: |
-          brew install make
-
-  helm-integration-test-release-linux:
-    if: inputs.target == 'release'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      # mono occupies port 8084 which conflicts with mgmt-backend
-      - name: Stop mono service
-        run: |
-          sudo kill -9 `sudo lsof -t -i:8084`
-          sudo lsof -i -P -n | grep LISTEN
-
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          overprovision-lvm: "true"
-          remove-dotnet: "true"
-          build-mount-path: "/var/lib/docker/"
-
-      - name: Restart docker
-        run: sudo service docker restart
-
-      - name: Start Minikube
-        run: minikube start --cpus 4 --memory 10485
-
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/instill-core
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Launch Helm Instill Core (release)
-        run: |
-          helm install core charts/core --namespace instill-ai --create-namespace \
-            --set edition=k8s-ce:test \
-            --set artifactBackend.image.tag=${ARTIFACT_BACKEND_VERSION} \
-            --set apiGateway.image.tag=${API_GATEWAY_VERSION} \
-            --set mgmtBackend.image.tag=${MGMT_BACKEND_VERSION} \
-            --set mgmtBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-            --set pipelineBackend.image.tag=${PIPELINE_BACKEND_VERSION} \
-            --set pipelineBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-            --set modelBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-            --set modelBackend.image.tag=${MODEL_BACKEND_VERSION} \
-            --set console.image.tag=${CONSOLE_VERSION} \
-            --set rayService.image.tag=${RAY_SERVER_VERSION} \
-            --set rayService.headGroupSpec.resources.limits.cpu=0 \
-            --set rayService.headGroupSpec.resources.limits.memory=2Gi \
-            --set rayService.headGroupSpec.resources.requests.cpu=0 \
-            --set rayService.headGroupSpec.resources.requests.memory=2Gi \
-            --set rayService.workerGroupSpecs[0].replicas=1 \
-            --set rayService.workerGroupSpecs[0].minReplicas=1 \
-            --set rayService.workerGroupSpecs[0].maxReplicas=1 \
-            --set rayService.workerGroupSpecs[0].groupName=test-group \
-            --set rayService.workerGroupSpecs[0].gpuWorkerGroup.enabled=false \
-            --set rayService.workerGroupSpecs[0].resources.limits.cpu=1 \
-            --set rayService.workerGroupSpecs[0].resources.limits.memory=2Gi \
-            --set rayService.workerGroupSpecs[0].resources.requests.cpu=1 \
-            --set rayService.workerGroupSpecs[0].resources.requests.memory=2Gi \
-            --set milvus.broker.resources.requests.cpu=0.25 \
-            --set milvus.autorecovery.resources.requests.cpu=0.25 \
-            --set milvus.proxy.resources.requests.cpu=0.25 \
-            --set tags.observability=false \
-            --set tags.prometheusStack=false
+          if [ "${{ inputs.target }}" == "latest" ]; then
+            helm install core charts/core --namespace instill-ai --create-namespace \
+              --set edition=k8s-ce:test \
+              --set artifactBackend.image.tag=latest \
+              --set apiGateway.image.tag=latest \
+              --set mgmtBackend.image.tag=latest \
+              --set pipelineBackend.image.tag=latest \
+              --set modelBackend.image.tag=latest \
+              --set console.image.tag=latest \
+              --set rayService.image.tag=latest \
+              --set rayService.headGroupSpec.resources.limits.cpu=0 \
+              --set rayService.headGroupSpec.resources.limits.memory=2Gi \
+              --set rayService.headGroupSpec.resources.requests.cpu=0 \
+              --set rayService.headGroupSpec.resources.requests.memory=2Gi \
+              --set rayService.workerGroupSpecs[0].replicas=1 \
+              --set rayService.workerGroupSpecs[0].minReplicas=1 \
+              --set rayService.workerGroupSpecs[0].maxReplicas=1 \
+              --set rayService.workerGroupSpecs[0].groupName=test-group \
+              --set rayService.workerGroupSpecs[0].gpuWorkerGroup.enabled=false \
+              --set rayService.workerGroupSpecs[0].resources.limits.cpu=1 \
+              --set rayService.workerGroupSpecs[0].resources.limits.memory=2Gi \
+              --set rayService.workerGroupSpecs[0].resources.requests.cpu=1 \
+              --set rayService.workerGroupSpecs[0].resources.requests.memory=2Gi \
+              --set milvus.broker.resources.requests.cpu=0.25 \
+              --set milvus.autorecovery.resources.requests.cpu=0.25 \
+              --set milvus.proxy.resources.requests.cpu=0.25 \
+              --set tags.observability=false \
+              --set tags.prometheusStack=false
+          else
+            helm install core charts/core --namespace instill-ai --create-namespace \
+              --set edition=k8s-ce:test \
+              --set artifactBackend.image.tag=${ARTIFACT_BACKEND_VERSION} \
+              --set apiGateway.image.tag=${API_GATEWAY_VERSION} \
+              --set mgmtBackend.image.tag=${MGMT_BACKEND_VERSION} \
+              --set mgmtBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
+              --set pipelineBackend.image.tag=${PIPELINE_BACKEND_VERSION} \
+              --set pipelineBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
+              --set modelBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
+              --set modelBackend.image.tag=${MODEL_BACKEND_VERSION} \
+              --set console.image.tag=${CONSOLE_VERSION} \
+              --set rayService.image.tag=${RAY_SERVER_VERSION} \
+              --set rayService.headGroupSpec.resources.limits.cpu=0 \
+              --set rayService.headGroupSpec.resources.limits.memory=2Gi \
+              --set rayService.headGroupSpec.resources.requests.cpu=0 \
+              --set rayService.headGroupSpec.resources.requests.memory=2Gi \
+              --set rayService.workerGroupSpecs[0].replicas=1 \
+              --set rayService.workerGroupSpecs[0].minReplicas=1 \
+              --set rayService.workerGroupSpecs[0].maxReplicas=1 \
+              --set rayService.workerGroupSpecs[0].groupName=test-group \
+              --set rayService.workerGroupSpecs[0].gpuWorkerGroup.enabled=false \
+              --set rayService.workerGroupSpecs[0].resources.limits.cpu=1 \
+              --set rayService.workerGroupSpecs[0].resources.limits.memory=2Gi \
+              --set rayService.workerGroupSpecs[0].resources.requests.cpu=1 \
+              --set rayService.workerGroupSpecs[0].resources.requests.memory=2Gi \
+              --set milvus.broker.resources.requests.cpu=0.25 \
+              --set milvus.autorecovery.resources.requests.cpu=0.25 \
+              --set milvus.proxy.resources.requests.cpu=0.25 \
+              --set tags.observability=false \
+              --set tags.prometheusStack=false
+          fi
 
       - name: Wait for all pods up
         run: |
@@ -233,10 +123,15 @@ jobs:
           while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 1; done
           while ! nc -vz localhost ${CONSOLE_PORT} > /dev/null 2>&1; do sleep 1; done
 
-      - name: Run console integration test (release)
+      - name: Run console integration test (${{ inputs.target }})
         run: |
-          git clone -b v$CONSOLE_VERSION https://github.com/instill-ai/console.git
-          cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:${{ env.CONSOLE_VERSION }} .
+          if [ "${{ inputs.target }}" == "latest" ]; then
+            git clone https://github.com/instill-ai/console.git
+            cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:latest .
+          else
+            git clone -b v$CONSOLE_VERSION https://github.com/instill-ai/console.git
+            cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:${{ env.CONSOLE_VERSION }} .
+          fi
           docker run -t \
             -e NEXT_PUBLIC_GENERAL_API_VERSION=v1beta \
             -e NEXT_PUBLIC_MODEL_API_VERSION=v1alpha \
@@ -248,36 +143,22 @@ jobs:
             -e NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user \
             --network host \
             --entrypoint ./entrypoint-playwright.sh \
-            --name core-console-integration-test-release \
-            console-playwright:${{ env.CONSOLE_VERSION }}
+            --name core-console-integration-test-${{ inputs.target }} \
+            console-playwright:${{ inputs.target == 'latest' && 'latest' || env.CONSOLE_VERSION }}
 
       - name: Copy the test-result to host
         if: always()
-        run: docker cp core-console-integration-test-release:/app/apps/console/test-results ./test-results
+        run: docker cp core-console-integration-test-${{ inputs.target }}:/app/apps/console/test-results ./test-results
 
       - name: Upload artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: helm-integration-test-release-linux-test-results
+          name: helm-integration-test-${{ inputs.target }}-linux-test-results
           path: test-results
           retention-days: 1
 
       - name: Stop and remove console playwright
         run: |
-          docker stop core-console-integration-test-release
-          docker rm core-console-integration-test-release
-
-  helm-integration-test-release-mac:
-    if: false
-    # disable the mac test temporary
-    # if: inputs.target == 'release'
-    runs-on: [self-hosted, macOS, core]
-    timeout-minutes: 60
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
-
-      - name: Set up environment
-        run: |
-          brew install make
+          docker stop core-console-integration-test-${{ inputs.target }}
+          docker rm core-console-integration-test-${{ inputs.target }}

--- a/.github/workflows/helm-integration-test-console.yml
+++ b/.github/workflows/helm-integration-test-console.yml
@@ -30,7 +30,7 @@ jobs:
           minikube start --cpus 4 --memory 10485
 
       - name: Checkout repo and load .env
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: instill-ai/instill-core
 

--- a/.github/workflows/helm-integration-test-latest.yml
+++ b/.github/workflows/helm-integration-test-latest.yml
@@ -11,13 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component:
-          [mgmt-backend, pipeline-backend, model-backend]
-    uses: instill-ai/instill-core/.github/workflows/helm-integration-test-backend.yml@main
+        component: [mgmt-backend, pipeline-backend, model-backend]
+    uses: ./.github/workflows/helm-integration-test-backend.yml
     with:
       component: ${{ matrix.component }}
       target: latest
   console:
-    uses: instill-ai/instill-core/.github/workflows/helm-integration-test-console.yml@main
+    uses: ./.github/workflows/helm-integration-test-console.yml
     with:
       target: latest

--- a/.github/workflows/helm-integration-test-release.yml
+++ b/.github/workflows/helm-integration-test-release.yml
@@ -8,13 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component:
-          [mgmt-backend, pipeline-backend, model-backend]
-    uses: instill-ai/instill-core/.github/workflows/helm-integration-test-backend.yml@main
+        component: [mgmt-backend, pipeline-backend, model-backend]
+    uses: ./.github/workflows/helm-integration-test-backend.yml
     with:
       component: ${{ matrix.component }}
       target: release
   console:
-    uses: instill-ai/instill-core/.github/workflows/helm-integration-test-console.yml@main
+    uses: ./.github/workflows/helm-integration-test-console.yml
     with:
       target: release

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -41,9 +41,14 @@ jobs:
         with:
           envFile: .env
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+
       - name: Install k6
         run: |
-          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
+          go install go.k6.io/xk6/cmd/xk6@v${{ env.XK6_VERSION }}
+          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql && sudo cp k6 /usr/bin
 
       - name: Launch Instill Core (${{ inputs.target }})
         run: |

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Launch Instill Core (${{ inputs.target }})
         run: |
           if [ "${{ inputs.target }}" == "latest" ]; then
-            make latest BUILD=true EDITION=local-ce:test
+            make latest BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test
           else
-            make all BUILD=true EDITION=local-ce:test
+            make all BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test
           fi
 
       - name: Uppercase component name

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo service docker restart
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: instill-ai/instill-core
 

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -11,10 +11,9 @@ on:
         type: string
 
 jobs:
-  integration-test-latest-linux:
-    if: inputs.target == 'latest'
+  integration-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
@@ -46,192 +45,28 @@ jobs:
         run: |
           curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
 
-      - name: Launch Instill Core (latest)
+      - name: Launch Instill Core (${{ inputs.target }})
         run: |
-          make latest BUILD=true EDITION=local-ce:test
+          if [ "${{ inputs.target }}" == "latest" ]; then
+            make latest BUILD=true EDITION=local-ce:test
+          else
+            make all BUILD=true EDITION=local-ce:test
+          fi
 
       - name: Uppercase component name
         id: uppercase
         run: |
           echo "COMPONENT_NAME=$(echo ${{ inputs.component }} | tr 'a-z-' 'A-Z_')" >> $GITHUB_OUTPUT
 
-      - name: Run ${{ inputs.component }} integration test (latest)
-        run: |
-          git clone https://github.com/instill-ai/${{ inputs.component }}.git
-          cd ${{ inputs.component }}
-          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
-
-      - name: Make down Instill Core
-        run: |
-          make down
-
-  integration-test-latest-mac:
-    if: false
-    # disable the mac test temporary
-    #if: inputs.target == 'latest'
-    runs-on: macos-latest
-    timeout-minutes: 120
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
-
-      - name: Install homebrew dependencies
-        run: |
-          brew install make
-          brew install k6
-          brew install docker docker-buildx docker-compose
-          mkdir -p ~/.docker/cli-plugins
-          ln -sfn $(which docker-buildx) ~/.docker/cli-plugins
-          ln -sfn $(which docker-compose) ~/.docker/cli-plugins
-
-      - name: Install and start Colima
-        run: |
-          brew install colima
-          colima version
-          colima start --cpu 3 --memory 14 --disk 100 --mount-type=sshfs
-
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/instill-core
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Launch Instill Core (latest)
-        run: |
-          make latest BUILD=true EDITION=local-ce:test
-
-      - name: Uppercase component name
-        id: uppercase
-        run: |
-          echo "COMPONENT_NAME=$(echo ${{ inputs.component }} | tr 'a-z-' 'A-Z_')" >> $GITHUB_OUTPUT
-
-      - name: Run ${{ inputs.component }} integration test (latest)
-        run: |
-          git clone https://github.com/instill-ai/${{ inputs.component }}.git
-          cd ${{ inputs.component }}
-          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
-
-      - name: Make down Instill Core
-        run: |
-          make down
-
-  integration-test-release-linux:
-    if: inputs.target == 'release'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      # mono occupies port 8084 which conflicts with mgmt-backend
-      - name: Stop mono service
-        run: |
-          sudo kill -9 `sudo lsof -t -i:8084`
-          sudo lsof -i -P -n | grep LISTEN
-
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          overprovision-lvm: "true"
-          remove-dotnet: "true"
-          build-mount-path: "/var/lib/docker/"
-
-      - name: Restart docker
-        run: sudo service docker restart
-
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/instill-core
-          fetch-depth: 5 # fetch the commit with tag
-          fetch-tags: true
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Install k6
-        run: |
-          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
-
-      - name: Launch Instill Core (release)
-        run: |
-          make all BUILD=true EDITION=local-ce:test
-
-      - name: Uppercase component name
-        id: uppercase
-        run: |
-          echo "COMPONENT_NAME=$(echo ${{ inputs.component }} | tr 'a-z-' 'A-Z_')" >> $GITHUB_OUTPUT
-
-      - name: Run ${{ inputs.component }} integration test (release)
+      - name: Run ${{ inputs.component }} integration test (${{ inputs.target }})
         env:
           COMPONENT_VERSION: ${{ env[format('{0}_VERSION', steps.uppercase.outputs.COMPONENT_NAME)] }}
         run: |
-          git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
-          cd ${{ inputs.component }}
-          make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
-
-      - name: Make down Instill Core
-        run: |
-          make down
-
-  integration-test-release-mac:
-    if: false
-    # disable the mac test temporary
-    # if: inputs.target == 'release'
-    runs-on: macos-latest
-    timeout-minutes: 120
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
-
-      - name: Install homebrew dependencies
-        run: |
-          brew install make
-          brew install k6
-          brew install docker docker-buildx docker-compose
-          mkdir -p ~/.docker/cli-plugins
-          ln -sfn $(which docker-buildx) ~/.docker/cli-plugins
-          ln -sfn $(which docker-compose) ~/.docker/cli-plugins
-
-      - name: Install and start Colima
-        run: |
-          brew install colima
-          colima version
-          colima start --cpu 3 --memory 14 --disk 100 --mount-type=sshfs --dns=1.1.1.1
-
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/instill-core
-          fetch-depth: 5 # fetch the commit with tag
-          fetch-tags: true
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Install k6
-        run: |
-          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
-
-      - name: Launch Instill Core (release)
-        run: |
-          make all BUILD=true EDITION=local-ce:test
-
-      - name: Uppercase component name
-        id: uppercase
-        run: |
-          echo "COMPONENT_NAME=$(echo ${{ inputs.component }} | tr 'a-z-' 'A-Z_')" >> $GITHUB_OUTPUT
-
-      - name: Run ${{ inputs.component }} integration test (release)
-        env:
-          COMPONENT_VERSION: ${{ env[format('{0}_VERSION', steps.uppercase.outputs.COMPONENT_NAME)] }}
-        run: |
-          git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
+          if [ "${{ inputs.target }}" == "latest" ]; then
+            git clone https://github.com/instill-ai/${{ inputs.component }}.git
+          else
+            git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
+          fi
           cd ${{ inputs.component }}
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Launch Instill Core (${{ inputs.target }})
         run: |
-          make ${{ inputs.target }} BUILD=true EDITION=local-ce:test INSTILL_CORE_HOST=api-gateway
+          make ${{ inputs.target }} BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test INSTILL_CORE_HOST=api-gateway
 
       - name: Run console integration test (${{ inputs.target }})
         run: |

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -29,7 +29,7 @@ jobs:
         run: sudo service docker restart
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: instill-ai/instill-core
 

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -8,10 +8,9 @@ on:
         type: string
 
 jobs:
-  integration-test-latest-linux:
-    if: inputs.target == 'latest'
+  integration-test-console:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
@@ -39,11 +38,11 @@ jobs:
         with:
           envFile: .env
 
-      - name: Launch Instill Core (latest)
+      - name: Launch Instill Core (${{ inputs.target }})
         run: |
-          make latest BUILD=true EDITION=local-ce:test INSTILL_CORE_HOST=api-gateway
+          make ${{ inputs.target }} BUILD=true EDITION=local-ce:test INSTILL_CORE_HOST=api-gateway
 
-      - name: Run console integration test (latest)
+      - name: Run console integration test (${{ inputs.target }})
         run: |
           git clone https://github.com/instill-ai/console.git
           cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:latest .
@@ -69,7 +68,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-test-latest-linux-test-results
+          name: integration-test-${{ inputs.target }}-console-test-results
           path: test-results
           retention-days: 1
 
@@ -81,115 +80,3 @@ jobs:
       - name: Make down Instill Core
         run: |
           make down
-
-  integration-test-latest-mac:
-    if: false
-    # disable the mac test temporary
-    # if: inputs.target == 'latest'
-    runs-on: [self-hosted, macOS, core]
-    timeout-minutes: 120
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
-
-      - name: remove existing docker container
-        run: |
-          docker rm -f $(docker ps -a -q) || true
-
-      - name: Set up environment
-        run: |
-          brew install make
-
-  integration-test-release-linux:
-    if: inputs.target == 'release'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      # mono occupies port 8084 which conflicts with mgmt-backend
-      - name: Stop mono service
-        run: |
-          sudo kill -9 `sudo lsof -t -i:8084`
-          sudo lsof -i -P -n | grep LISTEN
-
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          overprovision-lvm: "true"
-          remove-dotnet: "true"
-          build-mount-path: "/var/lib/docker/"
-
-      - name: Restart docker
-        run: sudo service docker restart
-
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/instill-core
-          fetch-depth: 5 # fetch the commit with tag
-          fetch-tags: true
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Launch Instill Core (release)
-        run: |
-          make all BUILD=true EDITION=local-ce:test INSTILL_CORE_HOST=api-gateway
-
-      - name: Run console integration test (release)
-        run: |
-          git clone -b v$CONSOLE_VERSION https://github.com/instill-ai/console.git
-          cd console && docker build --build-arg TEST_USER='root' -f Dockerfile.playwright -t console-playwright:${{ env.CONSOLE_VERSION }} .
-          docker run -t \
-            -e NEXT_PUBLIC_GENERAL_API_VERSION=v1beta \
-            -e NEXT_PUBLIC_MODEL_API_VERSION=v1alpha \
-            -e NEXT_PUBLIC_CONSOLE_EDITION=local-ce:test \
-            -e NEXT_PUBLIC_CONSOLE_BASE_URL=http://console:3000 \
-            -e NEXT_PUBLIC_API_GATEWAY_URL=http://${API_GATEWAY_HOST}:${API_GATEWAY_PORT}  \
-            -e NEXT_SERVER_API_GATEWAY_URL=http://${API_GATEWAY_HOST}:${API_GATEWAY_PORT}  \
-            -e NEXT_PUBLIC_SELF_SIGNED_CERTIFICATION=false \
-            -e NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user \
-            --network instill-network \
-            --entrypoint ./entrypoint-playwright.sh \
-            --name console-integration-test \
-            console-playwright:${{ env.CONSOLE_VERSION }}
-
-      - name: Copy the test-result to host
-        if: always()
-        run: docker cp console-integration-test:/app/apps/console/test-results ./test-results
-
-      - name: Upload artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: integration-test-release-linux-test-results
-          path: test-results
-          retention-days: 1
-
-      - name: Stop and remove console playwright
-        run: |
-          docker stop console-integration-test
-          docker rm console-integration-test
-
-      - name: Make down Instill Core
-        run: |
-          make down
-
-  integration-test-release-mac:
-    if: false
-    # disable the mac test temporary
-    # if: inputs.target == 'release'
-    runs-on: [self-hosted, macOS, core]
-    timeout-minutes: 60
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
-
-      - name: remove existing docker container
-        run: |
-          docker rm -f $(docker ps -a -q) || true
-
-      - name: Set up environment
-        run: |
-          brew install make

--- a/.github/workflows/integration-test-latest.yml
+++ b/.github/workflows/integration-test-latest.yml
@@ -11,13 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component:
-          [mgmt-backend, pipeline-backend, model-backend]
-    uses: instill-ai/instill-core/.github/workflows/integration-test-backend.yml@main
+        component: [mgmt-backend, pipeline-backend, model-backend]
+    uses: ./.github/workflows/integration-test-backend.yml
     with:
       component: ${{ matrix.component }}
       target: latest
   console:
-    uses: instill-ai/instill-core/.github/workflows/integration-test-console.yml@main
+    uses: ./.github/workflows/integration-test-console.yml
     with:
       target: latest

--- a/.github/workflows/integration-test-release.yml
+++ b/.github/workflows/integration-test-release.yml
@@ -8,13 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component:
-          [mgmt-backend, pipeline-backend, model-backend]
-    uses: instill-ai/instill-core/.github/workflows/integration-test-backend.yml@main
+        component: [mgmt-backend, pipeline-backend, model-backend]
+    uses: ./.github/workflows/integration-test-backend.yml
     with:
       component: ${{ matrix.component }}
       target: release
   console:
-    uses: instill-ai/instill-core/.github/workflows/integration-test-console.yml@main
+    uses: ./.github/workflows/integration-test-console.yml
     with:
       target: release

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -24,7 +24,7 @@ jobs:
         run: sudo service docker restart
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: instill-ai/instill-core
 

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -33,9 +33,14 @@ jobs:
         with:
           envFile: .env
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+  
       - name: Install k6
         run: |
-          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
+          go install go.k6.io/xk6/cmd/xk6@v${{ env.XK6_VERSION }}
+          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql && sudo cp k6 /usr/bin
 
       - name: Launch Instill Core (release)
         run: |

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Launch Instill Core (release)
         run: |
-          make all BUILD=true EDITION=local-ce:test
+          make all BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test
 
       - name: List all docker containers
         run: |

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo service docker restart
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: instill-ai/instill-core
 

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Launch Instill Core (latest)
         run: |
-          make latest BUILD=true EDITION=local-ce:test
+          make latest BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test
 
       - name: List all docker containers
         run: |

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -37,9 +37,14 @@ jobs:
         with:
           envFile: .env
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+  
       - name: Install k6
         run: |
-          curl https://github.com/grafana/k6/releases/download/v${{ env.K6_VERSION }}/k6-v${{ env.K6_VERSION }}-linux-amd64.tar.gz -L | tar xvz --strip-components 1 && sudo cp k6 /usr/bin
+          go install go.k6.io/xk6/cmd/xk6@v${{ env.XK6_VERSION }}
+          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql && sudo cp k6 /usr/bin
 
       - name: Launch Instill Core (latest)
         run: |

--- a/.github/workflows/releases-helm-charts.yml
+++ b/.github/workflows/releases-helm-charts.yml
@@ -16,7 +16,7 @@ jobs:
       HELM_CHART_REPO_BRANCH: main
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.botGitHubToken }}
 
@@ -74,7 +74,7 @@ jobs:
           echo "dir=${PACKAGES}" >> $GITHUB_OUTPUT
 
       - name: Checkout Helm chart repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ env.HELM_CHART_REPO }}
           path: .helm-chart-repo

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -25,7 +25,7 @@ jobs:
           config-file: release-please/config.json
           manifest-file: release-please/manifest.json
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}
         with:
           token: ${{ secrets.botGitHubToken }}
@@ -69,7 +69,7 @@ jobs:
             ".assets[] | select(.name | test("\""^helm-docs_.+_Linux_${arch}\.tar\.gz$"\"")) | .browser_download_url" \
           | xargs curl -SsL \
           | tar zxf - -C /usr/local/bin
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.botGitHubToken }}
       - name: Update component image versions

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ else
 endif
 
 .PHONY: build-latest
-build-latest:				## Build latest images for all Instill Core components
+build-latest:				## Build latest images for all services
 	@if [ "${BUILD}" = "true" ]; then \
 		docker build --progress plain \
 			--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
@@ -103,7 +103,7 @@ build-latest:				## Build latest images for all Instill Core components
 	fi
 
 .PHONY: build-release
-build-release:				## Build release images for all Instill Core components
+build-release:				## Build release images for all services
 	@if [ "${BUILD}" = "true" ]; then \
 		docker build --progress plain \
 			--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
@@ -179,7 +179,7 @@ doc:			## Run Redoc for OpenAPI spec at http://localhost:3001
 	@EDITION= DEFAULT_USER_UID= docker compose up -d redoc_openapi
 
 .PHONY: integration-test-latest
-integration-test-latest:			## Run integration test on the latest VDP
+integration-test-latest:			# Run integration test on the latest VDP
 	@make latest BUILD=true EDITION=local-ce:test
 	@docker run --rm \
 		--network instill-network \
@@ -192,7 +192,7 @@ integration-test-latest:			## Run integration test on the latest VDP
 	@make down
 
 .PHONY: integration-test-release
-integration-test-release:			## Run integration test on the release VDP
+integration-test-release:			# Run integration test on the release VDP
 	@make all BUILD=true EDITION=local-ce:test
 	@docker run --rm \
 		--network instill-network \
@@ -205,7 +205,7 @@ integration-test-release:			## Run integration test on the release VDP
 	@make down
 
 .PHONY: helm-integration-test-latest
-helm-integration-test-latest:                       ## Run integration test on the Helm latest for VDP
+helm-integration-test-latest:                       # Run integration test on the Helm latest for VDP
 	@make build-latest BUILD=true
 	@helm install ${HELM_RELEASE_NAME} charts/core \
 		--namespace ${HELM_NAMESPACE} --create-namespace \
@@ -245,7 +245,7 @@ endif
 	@make down
 
 .PHONY: helm-integration-test-release
-helm-integration-test-release:                       ## Run integration test on the Helm release for VDP
+helm-integration-test-release:                       # Run integration test on the Helm release for VDP
 	@make build-release BUILD=true
 	@helm install ${HELM_RELEASE_NAME} charts/core \
 		--namespace ${HELM_NAMESPACE} --create-namespace \
@@ -285,7 +285,7 @@ endif
 	@make down
 
 .PHONY: console-integration-test-latest
-console-integration-test-latest:			## Run console integration test on the latest Instill Core
+console-integration-test-latest:			# Run console integration test on the latest Instill Core
 	@make latest BUILD=true EDITION=local-ce:test INSTILL_CORE_HOST=${API_GATEWAY_HOST}
 	@docker run --rm \
 		-e NEXT_PUBLIC_GENERAL_API_VERSION=v1beta \
@@ -303,7 +303,7 @@ console-integration-test-latest:			## Run console integration test on the latest
 	@make down
 
 .PHONY: console-integration-test-release
-console-integration-test-release:			## Run console integration test on the release Instill Core
+console-integration-test-release:			# Run console integration test on the release Instill Core
 	@make all BUILD=true EDITION=local-ce:test INSTILL_CORE_HOST=${API_GATEWAY_HOST}
 	@docker run --rm \
 		-e NEXT_PUBLIC_GENERAL_API_VERSION=v1beta \
@@ -321,7 +321,7 @@ console-integration-test-release:			## Run console integration test on the relea
 	@make down
 
 .PHONY: console-helm-integration-test-latest
-console-helm-integration-test-latest:                       ## Run console integration test on the Helm latest for Instill Core
+console-helm-integration-test-latest:                       # Run console integration test on the Helm latest for Instill Core
 	@make build-latest  BUILD=true
 ifeq ($(UNAME_S),Darwin)
 	@helm install ${HELM_RELEASE_NAME} charts/core --namespace ${HELM_NAMESPACE} --create-namespace \
@@ -401,7 +401,7 @@ endif
 	@make down
 
 .PHONY: console-helm-integration-test-release
-console-helm-integration-test-release:                       ## Run console integration test on the Helm release for Instill Core
+console-helm-integration-test-release:                       # Run console integration test on the Helm release for Instill Core
 	@make build-release  BUILD=true
 ifeq ($(UNAME_S),Darwin)
 	@helm install ${HELM_RELEASE_NAME} charts/core --namespace ${HELM_NAMESPACE} --create-namespace \
@@ -482,5 +482,5 @@ endif
 
 .PHONY: help
 help:       	## Show this help
-	@echo "\nMake Application with Docker Compose"
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m (default: help)\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@echo "\nMake Application with Instill Core"
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m (default: help)\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ endif
 
 .PHONY: build-latest
 build-latest:				## Build latest images for all services
-	@if [ "${BUILD}" = "true" ]; then \
+	@if [ "${BUILD}" = "true" ] || [ "${BUILD_CORE_DEV_IMAGE}" = "true" ]; then \
 		docker build --progress plain \
 			--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
 			--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
@@ -86,6 +86,8 @@ build-latest:				## Build latest images for all services
 			--build-arg CACHE_DATE="$(shell date)" \
 			--target latest \
 			-t ${INSTILL_CORE_IMAGE_NAME}:latest .; \
+	fi
+	@if [ "${BUILD}" = "true" ]; then \
 		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v ./.env:/instill-core/.env \
@@ -104,7 +106,7 @@ build-latest:				## Build latest images for all services
 
 .PHONY: build-release
 build-release:				## Build release images for all services
-	@if [ "${BUILD}" = "true" ]; then \
+	@if [ "${BUILD}" = "true" ] || [ "${BUILD_CORE_DEV_IMAGE}" = "true" ]; then \
 		docker build --progress plain \
 			--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
 			--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
@@ -119,6 +121,8 @@ build-release:				## Build release images for all services
 			--build-arg CONSOLE_VERSION=${CONSOLE_VERSION} \
 			--target release \
 			-t ${INSTILL_CORE_IMAGE_NAME}:${INSTILL_CORE_VERSION} .; \
+	fi
+	@if [ "${BUILD}" = "true" ]; then \
 		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v ./.env:/instill-core/.env \


### PR DESCRIPTION
Because

- we can safely run the integration tests on only Linux because instill-core relies on Docker Desktop on MacOS.
- as the codebase continues to evolve the `timeout 60` for the integration tests is no longer enough

This commit

- remove integration tests for MacOS
- increase timeout to 120
- upgrade to actions/checkout@v4 to address the warning:
- disable image build in integration-test

```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```