### PR TITLE
chore(helm): add task schema version and bump model db version

### DIFF
--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -26,6 +26,7 @@ data:
         key: /etc/instill-ai/model/ssl/model/tls.key
       {{- end }}
       instillcorehost: {{ .Values.modelBackend.instillCoreHost }}
+      instillcorehost: {{ .Values.modelBackend.taskSchemaVersion }}
     log:
       external: {{ .Values.tags.observability }}
       otelcollector:
@@ -77,15 +78,6 @@ data:
       redis:
         redisoptions:
           addr: {{ default (include "core.redis.addr" .) .Values.redis.external.addr }}
-    maxbatchsizelimitation:
-      unspecified: 2
-      classification: 16
-      detection: 8
-      keypoint: 8
-      ocr: 2
-      instancesegmentation: 8
-      semanticsegmentation: 8
-      textgeneration: 1
     temporal:
       hostport: {{ default (printf "%s-frontend-headless:%s" (include "core.temporal" .) (include "core.temporal.frontend.grpcPort" .)) .Values.modelBackend.temporal.hostPort }}
       namespace: {{ default "model-backend" .Values.modelBackend.temporal.namespace }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -478,8 +478,10 @@ modelBackend:
   # -- The path of configuration file for model-backend
   configPath: /model-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 9
+  dbVersion: 10
   instillCoreHost:
+  # -- The AI Task schema version
+  taskSchemaVersion: 78133b5
   # -- The configuration of Temporal Cloud
   temporal:
     hostPort:


### PR DESCRIPTION
Because

- model-backend configs changed

This commit

- add task schema version hash in values.yaml
- bump model db version
