### PR TITLE
chore(schema): fix text-to-image output instillformat

### DIFF
--- a/schema/ai-tasks.json
+++ b/schema/ai-tasks.json
@@ -973,7 +973,7 @@
                                         "type": "string",
                                         "description": "The generated image, encoded to base64.",
                                         "instillShortDescription": "The generated image, encoded to base64.",
-                                        "instillFormat": "string"
+                                        "instillFormat": "image/*"
                                     }
                                 },
                                 "required": [


### PR DESCRIPTION
Because

- text-to-image output schema has wrong instillformat

This commit

- fix text-to-image output instillformat

resolves INS-6230