### PR TITLE
chore(helm): add additional host to api-gateway configmap

### DIFF
--- a/charts/core/templates/api-gateway/configmap.yaml
+++ b/charts/core/templates/api-gateway/configmap.yaml
@@ -47,3 +47,14 @@ data:
     # registry
     REGISTRY_HOST={{ template "core.registry" . }}
     REGISTRY_PORT={{ template "core.registry.port" . }}
+
+    # Additional Hosts
+    {{- range $key, $host := .Values.apiGateway.additionalHosts }}
+    {{ $host.name }}_HOST={{ $host.host }}
+    {{- if $host.publicPort }}
+    {{ $host.name }}_PUBLICPORT={{ $host.publicPort }}
+    {{- end }}
+    {{- if $host.privatePort }}
+    {{ $host.name }}_PRIVATEPORT={{ $host.privatePort }}
+    {{- end }}
+    {{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -250,6 +250,8 @@ apiGateway:
     pullPolicy: IfNotPresent
   # -- The path of configuration file for api-gateway
   configPath: /api-gateway/config/.env
+  # -- Additional hosts
+  additionalHosts: []
   # -- The TLS configuration for api-gateway
   tls:
     enabled: false


### PR DESCRIPTION
Because

- api-gateway will potentially need to connect to additional hosts

This commit

- add additional host to api-gateway configmap
