### PR TITLE
chore(vdp): bump database version

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -390,7 +390,7 @@ pipelineBackend:
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 29
+  dbVersion: 30
   # -- workflow setting
   workflow:
     maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- https://github.com/instill-ai/pipeline-backend/pull/699 introduces a new
  database version.

This commit

- Updates the database version.
