### PR TITLE
fix(minio): add more retry for liveness probe

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1566,6 +1566,20 @@ milvus:
     replicas: 2
     persistence:
       size: 50Gi
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      timeoutSeconds: 10
+      successThreshold: 1
+      failureThreshold: 10
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 1
+      successThreshold: 1
+      failureThreshold: 5
   etcd:
     nodeSelector: {}
     enabled: true


### PR DESCRIPTION
Because

when minIO is busy, the k8s restart it too quick.

This commit

increases the retry of liveness probe