### PR TITLE
chore(helm): update model task schema version

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -483,7 +483,7 @@ modelBackend:
   dbVersion: 11
   instillCoreHost:
   # -- The AI Task schema version
-  taskSchemaVersion: 2496179
+  taskSchemaVersion: 662c3e2
   # -- The configuration of Temporal Cloud
   temporal:
     hostPort:


### PR DESCRIPTION
Because

- AI task schema version is outdated in model-backend configmap

This commit

- update model task schema version
