### PR TITLE
feat(helm): support isolated namespace for ray cluster

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
     repository: https://ray-project.github.io/kuberay-helm/
     version: 1.1.1
     tags:
-      - model
+      - ray
   - name: elasticsearch
     repository: https://helm.elastic.co
     version: 7.17.3

--- a/charts/core/templates/_helpers.tpl
+++ b/charts/core/templates/_helpers.tpl
@@ -35,6 +35,28 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 {{- end -}}
 
 {{/*
+Ray fullname
+*/}}
+{{- define "ray.fullname" -}}
+  {{- if .Values.rayService.namespaceOverride -}}
+    {{- .Values.rayService.namespaceOverride -}}
+  {{- else -}}
+    {{- printf "%s" (include "core.name" .) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Inter namespace DNS suffix
+*/}}
+{{- define "ray.suffix" -}}
+  {{- if .Values.rayService.namespaceOverride -}}
+    {{- printf ".%s.svc.cluster.local" (include "ray.fullname" .) -}}
+  {{- else -}}
+    {{- printf "" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "core.chart" -}}
@@ -243,15 +265,15 @@ temopral
 {{- end -}}
 
 {{- define "core.kuberay-operator" -}}
-  {{- printf "%s-kuberay-operator" (include "core.fullname" .) -}}
+  {{- printf "%s-kuberay-operator" (include "ray.fullname" .) -}}
 {{- end -}}
 
 {{- define "core.ray-service" -}}
-  {{- printf "%s-ray" (include "core.fullname" .) -}}
+  {{- printf "%s-ray" (include "ray.fullname" .) -}}
 {{- end -}}
 
 {{- define "core.ray" -}}
-  {{- printf "%s-ray-head-svc" (include "core.fullname" .) -}}
+  {{- printf "%s-ray-head-svc%s" (include "ray.fullname" .) (include "ray.suffix" .) -}}
 {{- end -}}
 
 {{- define "core.ray.clientPort" -}}

--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -98,7 +98,11 @@ data:
         replicationtimeframe: 1
       {{- end }}
     registry:
+      {{- if .Values.rayService.namespaceOverride }}
+      host: {{ include "core.registry" . }}.{{ include "core.namespace" . }}.svc.cluster.local
+      {{- else }}
       host: {{ template "core.registry" . }}
+      {{- end }}
       port: {{ template "core.registry.port" . }}
     influxdb:
       url: {{ .Values.influxdbCloud.url }}

--- a/charts/core/templates/ray-service/monitor.yaml
+++ b/charts/core/templates/ray-service/monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tags.model -}}
+{{- if .Values.tags.ray -}}
 {{- if .Values.tags.prometheusStack }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/core/templates/ray-service/ray-service.yaml
+++ b/charts/core/templates/ray-service/ray-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tags.model -}}
+{{- if .Values.tags.ray -}}
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -688,6 +688,7 @@ kuberay-operator:
     - "instill-ai"
 # -- The configuration of Ray
 rayService:
+  namespaceOverride:
   vram:
   spec:
     autoscalerOptions:
@@ -1641,6 +1642,7 @@ milvus:
       pulsar:
         namespace: instill-ai
 tags:
+  ray: true
   model: true
   observability: false
   prometheusStack: false


### PR DESCRIPTION
Because

- allow user to install `RayCluster` in separate namespace

This commit

- support separate namespace installation for `RayCluster`
