### PR TITLE
chore(helm): update pipeline db version

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -390,7 +390,7 @@ pipelineBackend:
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 32
+  dbVersion: 35
   # -- workflow setting
   workflow:
     maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- pipeline db version needs to be updated.
- related PR at: https://github.com/instill-ai/pipeline-backend/pull/776

This commit

- update pipeline db version to 35.
