### PR TITLE
fix(component): add dummy OAuth information for pipeline-backend tests

### DIFF
--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -51,7 +51,10 @@ jobs:
           xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql && sudo cp k6 /usr/bin
 
       - name: Launch Instill Core (${{ inputs.target }})
+        # CFG_COMPONENT_SECRETS_GITHUB* variables are injected to test OAuth
+        # connection creation on `pipeline-backend`.
         run: |
+          sed -i 's/\(\w\+GITHUB\w\+\)=/\1=foo/' .env.component
           if [ "${{ inputs.target }}" == "latest" ]; then
             make latest BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test
           else


### PR DESCRIPTION
Because

- Latest `pipeline-backend` tests OAuth connection creation using some environment variables ([ref](https://github.com/instill-ai/pipeline-backend/blob/main/.github/workflows/integration-test.yml#L80))

This commit

- Adds such variables to the build on the CI.
