### PR TITLE
fix(api-gateway): add minio port in _helpers.tpl

### DIFF
--- a/charts/core/templates/_helpers.tpl
+++ b/charts/core/templates/_helpers.tpl
@@ -501,3 +501,7 @@ minio
 {{- define "core.minio" -}}
   {{- printf "%s-minio" (include "core.fullname" .) -}}
 {{- end -}}
+
+{{- define "core.minio.port" -}}
+  {{- printf "9000" -}}
+{{- end -}}


### PR DESCRIPTION
Because

there is a lack on helpers.tpl

This commit

adds a new Helm template helper `core.minio.port` to define MinIO's default port (9000)