### PR TITLE
chore(ci): pin xk6-sql to a specific version to maintain compatibility

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install k6
         run: |
           go install go.k6.io/xk6/cmd/xk6@v${{ env.XK6_VERSION }}
-          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql && sudo cp k6 /usr/bin
+          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql@v0.4.1 && sudo cp k6 /usr/bin
 
       - name: Launch Helm Instill Core (${{ inputs.target }})
         run: |

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install k6
         run: |
           go install go.k6.io/xk6/cmd/xk6@v${{ env.XK6_VERSION }}
-          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql && sudo cp k6 /usr/bin
+          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql@v0.4.1 && sudo cp k6 /usr/bin
 
       - name: Launch Instill Core (${{ inputs.target }})
         # CFG_COMPONENT_SECRETS_GITHUB* variables are injected to test OAuth

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install k6
         run: |
           go install go.k6.io/xk6/cmd/xk6@v${{ env.XK6_VERSION }}
-          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql && sudo cp k6 /usr/bin
+          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql@v0.4.1 && sudo cp k6 /usr/bin
 
       - name: Launch Instill Core (release)
         run: |

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install k6
         run: |
           go install go.k6.io/xk6/cmd/xk6@v${{ env.XK6_VERSION }}
-          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql && sudo cp k6 /usr/bin
+          xk6 build v${{ env.K6_VERSION }} --with github.com/grafana/xk6-sql@v0.4.1 && sudo cp k6 /usr/bin
 
       - name: Launch Instill Core (latest)
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --update docker docker-compose docker-cli-compose docker-cli-buildx 
 
 ARG XK6_VERSION K6_VERSION
 RUN go install go.k6.io/xk6/cmd/xk6@v${XK6_VERSION}
-RUN xk6 build v${K6_VERSION} --with github.com/grafana/xk6-sql --output /usr/bin/k6
+RUN xk6 build v${K6_VERSION} --with github.com/grafana/xk6-sql@v0.4.1 --output /usr/bin/k6
 
 # Install Helm
 RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash


### PR DESCRIPTION
Because

 - xk6-sql released a new version with breaking changes.

This commit

 - Pins xk6-sql to a specific version to maintain compatibility.