### PR TITLE
feat(blob/artifact): add blob domain in config

### DIFF
--- a/charts/core/templates/artifact-backend/configmap.yaml
+++ b/charts/core/templates/artifact-backend/configmap.yaml
@@ -89,3 +89,5 @@ data:
       port: {{ template "core.milvus.port" . }}
     filetoembeddingworker:
       numberofworkers: {{ .Values.artifactBackend.numberOfWorkers }}
+    blob:
+      hostport: {{ .Values.artifactBackend.blob.hostport }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -621,6 +621,8 @@ artifactBackend:
     rootpwd: minioadmin
     bucketname: instill-ai-knowledge-bases
   numberOfWorkers: 20
+  blob:
+    hostport: http://localhost:8080
 # -- The configuration of console
 console:
   # -- Enable console deployment or not


### PR DESCRIPTION
Because

blob service in artifact need the config to know the its domain

This commit

add the blob domain in config for different environment