### PR TITLE
chore(helm): update pipeline database version

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -390,7 +390,7 @@ pipelineBackend:
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 38
+  dbVersion: 39
   # -- workflow setting
   workflow:
     maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- `pipeline-backend` added a new DB version in https://github.com/instill-ai/pipeline-backend/pull/938.

This commit

- Updates the version in the helm charts.
