### PR TITLE
chore(docker): fix image build problem for pipeline-backend

### DIFF
--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -44,7 +44,6 @@ services:
       context: ./${PIPELINE_BACKEND_HOST}
       args:
         SERVICE_NAME: ${PIPELINE_BACKEND_HOST}
-        GOLANG_VERSION: ${GOLANG_VERSION}
 
   model_backend:
     profiles:


### PR DESCRIPTION
Because

- The pipeline-backend image could not be built due to a Golang version mismatch.

This commit

- Resolves the image build issue for pipeline-backend.

Note:
We plan to remove the library version override in the future. Each microservice will fully control its versioning, eliminating reliance on the .env file in this repository.