### PR TITLE
fix(ci): remove step to stop mono service

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -15,11 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - name: Setup environment
-        run: |
-          sudo kill -9 `sudo lsof -t -i:8084`
-          sudo lsof -i -P -n | grep LISTEN
-
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:

--- a/.github/workflows/helm-integration-test-console.yml
+++ b/.github/workflows/helm-integration-test-console.yml
@@ -12,11 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - name: Setup environment
-        run: |
-          sudo kill -9 `sudo lsof -t -i:8084`
-          sudo lsof -i -P -n | grep LISTEN
-
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -15,12 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      # mono occupies port 8084 which conflicts with mgmt-backend
-      - name: Stop mono service
-        run: |
-          sudo kill -9 `sudo lsof -t -i:8084`
-          sudo lsof -i -P -n | grep LISTEN
-
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -12,12 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      # mono occupies port 8084 which conflicts with mgmt-backend
-      - name: Stop mono service
-        run: |
-          sudo kill -9 `sudo lsof -t -i:8084`
-          sudo lsof -i -P -n | grep LISTEN
-
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -7,12 +7,6 @@ jobs:
   make-all:
     runs-on: ubuntu-latest
     steps:
-      # mono occupies port 8084 which conflicts with mgmt-backend
-      - name: Stop mono service
-        run: |
-          sudo kill -9 `sudo lsof -t -i:8084`
-          sudo lsof -i -P -n | grep LISTEN
-
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -11,12 +11,6 @@ jobs:
   make-latest:
     runs-on: ubuntu-latest
     steps:
-      # mono occupies port 8084 which conflicts with mgmt-backend
-      - name: Stop mono service
-        run: |
-          sudo kill -9 `sudo lsof -t -i:8084`
-          sudo lsof -i -P -n | grep LISTEN
-
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:


### PR DESCRIPTION
Because

- mono service no longer exist in github runner instance

This commit

- remove step to stop mono service
