### PR TITLE
fix(workflow): fix release helm chart github action workflow

### DIFF
--- a/.github/workflows/releases-helm-charts.yml
+++ b/.github/workflows/releases-helm-charts.yml
@@ -86,6 +86,8 @@ jobs:
           GH_TOKEN: ${{ secrets.botGitHubToken }}
         run: |
           set -ex
+          git checkout -b origin/gh-pages
+          git ls-remote --heads origin
           repo=core
           tag=$repo-$(yq -r '.version' ../charts/$repo/Chart.yaml)
           gh release delete $tag --cleanup-tag --yes || true


### PR DESCRIPTION
Because

- The workflow was not able to fetch the gh-pages origin

This commit

- fix release helm chart github action workflow
