### PR TITLE
fix(test): inject dummy OAuth values in integration tests

### DIFF
--- a/.env.component-test
+++ b/.env.component-test
@@ -1,0 +1,4 @@
+# CFG_COMPONENT_SECRETS_GITHUB* variables are injected to test OAuth
+# connection creation on `pipeline-backend`.
+CFG_COMPONENT_SECRETS_GITHUB_OAUTHCLIENTID=foo
+CFG_COMPONENT_SECRETS_GITHUB_OAUTHCLIENTSECRET=foo

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -51,11 +51,10 @@ jobs:
         # CFG_COMPONENT_SECRETS_GITHUB* variables are injected to test OAuth
         # connection creation on `pipeline-backend`.
         run: |
-          sed -i 's/\(\w\+GITHUB\w\+\)=/\1=foo/' .env.component
           if [ "${{ inputs.target }}" == "latest" ]; then
-            make latest BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test
+            make latest BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test COMPONENT_ENV=.env.component-test
           else
-            make all BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test
+            make all BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test COMPONENT_ENV=.env.component-test
           fi
 
       - name: Uppercase component name

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
     container_name: ${PIPELINE_BACKEND_HOST}
     image: ${PIPELINE_BACKEND_IMAGE}:${PIPELINE_BACKEND_VERSION}
     restart: unless-stopped
-    env_file: .env.component
+    env_file: ${COMPONENT_ENV}
     environment:
       CFG_SERVER_PRIVATEPORT: ${PIPELINE_BACKEND_PRIVATEPORT}
       CFG_SERVER_PUBLICPORT: ${PIPELINE_BACKEND_PUBLICPORT}
@@ -191,7 +191,7 @@ services:
     container_name: ${PIPELINE_BACKEND_HOST}-worker
     image: ${PIPELINE_BACKEND_IMAGE}:${PIPELINE_BACKEND_VERSION}
     restart: unless-stopped
-    env_file: .env.component
+    env_file: ${COMPONENT_ENV}
     environment:
       CFG_SERVER_PRIVATEPORT: ${PIPELINE_BACKEND_PRIVATEPORT}
       CFG_SERVER_PUBLICPORT: ${PIPELINE_BACKEND_PUBLICPORT}
@@ -359,7 +359,7 @@ services:
     image: ${CONSOLE_IMAGE}:${CONSOLE_VERSION}
     restart: unless-stopped
     env_file:
-      - path: .env.component
+      - path: ${COMPONENT_ENV}
       - path: .env.console
     environment:
       NEXT_PUBLIC_GENERAL_API_VERSION: v1beta


### PR DESCRIPTION
Because

- Integration tests passed on the CI because dummy values were injected for
  the OAuth configuration. This was required to enable OAuth for the GitHub
  component, whose OAuth integration was later tested. On local testing,
  however, we relied on these values to be present on .env.component

This commit

- Creates an .env.component-test file, which contains the dummy values.
  This is used on `make *test*` in order not to overwrite local
  configuration values.
