### PR TITLE
ci(Makefile): remove build-related env variables

### DIFF
--- a/.env
+++ b/.env
@@ -5,9 +5,6 @@ COMPOSE_PROJECT_NAME=instill-core
 # the value can be all, exclude-api-gateway, exclude-mgmt, exclude-pipeline, exclude-model, or exclude-console.
 PROFILE=all
 
-# build from scratch or not at launch, which will build all sources from scrach. Default to false.
-BUILD=false
-
 # system-wise config path (all vdp, model and artifact projects must use the same path)
 SYSTEM_CONFIG_PATH=~/.config/instill
 
@@ -20,7 +17,7 @@ USAGE_ENABLED=true
 # flag to enable observability stack
 OBSERVE_ENABLED=false
 
-# flag to enable model-backend creating predploy models
+# flag to enable model-backend creating pre-dploy models
 INITMODEL_ENABLED=false
 
 # configuration directory path
@@ -108,13 +105,13 @@ POSTGRESQL_VERSION=14.1
 POSTGRESQL_HOST=pg-sql
 POSTGRESQL_PORT=5432
 
-# Elasticseach
+# Elasticsearch
 ELASTICSEARCH_IMAGE=elasticsearch
 ELASTICSEARCH_VERSION=7.16.2
 ELASTICSEARCH_HOST=elasticsearch
 ELASTICSEARCH_PORT=9200
 
-# Temopral
+# Temporal
 TEMPORAL_IMAGE=temporalio/auto-setup
 TEMPORAL_VERSION=1.22.3
 TEMPORAL_HOST=temporal
@@ -137,7 +134,7 @@ INFLUXDB_VERSION=2.7
 INFLUXDB_HOST=influxdb
 INFLUXDB_PORT=8086
 
-# opengfa
+# OpenFGA
 OPENFGA_IMAGE=openfga/openfga
 OPENFGA_VERSION=v1.5.1
 OPENFGA_HOST=openfga

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -52,9 +52,9 @@ jobs:
         # connection creation on `pipeline-backend`.
         run: |
           if [ "${{ inputs.target }}" == "latest" ]; then
-            make latest BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test COMPONENT_ENV=.env.component-test
+            make latest EDITION=local-ce:test COMPONENT_ENV=.env.component-test
           else
-            make all BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test COMPONENT_ENV=.env.component-test
+            make all EDITION=local-ce:test COMPONENT_ENV=.env.component-test
           fi
 
       - name: Uppercase component name

--- a/.github/workflows/integration-test-console.yml
+++ b/.github/workflows/integration-test-console.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Launch Instill Core (${{ inputs.target }})
         run: |
-          make ${{ inputs.target }} BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test INSTILL_CORE_HOST=api-gateway
+          make ${{ inputs.target }} EDITION=local-ce:test INSTILL_CORE_HOST=api-gateway
 
       - name: Run console integration test (${{ inputs.target }})
         run: |

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Launch Instill Core (release)
         run: |
-          make all BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test
+          make all EDITION=local-ce:test
 
       - name: List all docker containers
         run: |

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Launch Instill Core (latest)
         run: |
-          make latest BUILD_CORE_DEV_IMAGE=true EDITION=local-ce:test
+          make latest EDITION=local-ce:test
 
       - name: List all docker containers
         run: |


### PR DESCRIPTION
Because

- the Makefile targets are for local development and testing purpose, the the service images have been also built from scratch to ensure integrity. In this case, `BUILD` and `BUILD_CORE_DEV_IMAGE` are redundant as they have been set always `true` anyway.

This commit

- remove `BUILD` and `BUILD_CORE_DEV_IMAGE` env variables
- remove `make build-release` in `make all` and `make build-latest` in `make latest`, i.e., `make all` and `make latest` will use only remote pre-built images and won't build service images locally
- fix typos
