### PR TITLE
chore(helm,docker): add artifact-backend-init cmd

### DIFF
--- a/charts/core/templates/artifact-backend/deployment.yaml
+++ b/charts/core/templates/artifact-backend/deployment.yaml
@@ -73,6 +73,29 @@ spec:
             - name: config
               mountPath: {{ .Values.artifactBackend.configPath }}
               subPath: config.yaml
+        - name: wait-for-dependencies
+          image: curlimages/curl:8.00.1
+          command: ['sh', '-c']
+          args:
+          - >
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${PIPELINE_BACKEND_HOST}:${PIPELINE_BACKEND_PORT}/v1beta/__readiness)" != "200" ]]; do echo waiting for pipeline-backend; sleep 1; done
+          env:
+            - name: PIPELINE_BACKEND_HOST
+              value: "{{ template "core.pipelineBackend" . }}"
+            - name: PIPELINE_BACKEND_PORT
+              value: "{{ template "core.pipelineBackend.publicPort" . }}"
+        - name: artifact-backend-init
+          image: {{ .Values.artifactBackend.image.repository }}:{{ .Values.artifactBackend.image.tag }}
+          imagePullPolicy: {{ .Values.artifactBackend.image.pullPolicy }}
+          command: [./{{ .Values.artifactBackend.commandName.init }}]
+          volumeMounts:
+            - name: config
+              mountPath: {{ .Values.artifactBackend.configPath }}
+              subPath: config.yaml
+          env:
+          {{- if .Values.artifactBackend.extraEnv }}
+            {{- toYaml .Values.artifactBackend.extraEnv | nindent 12 }}
+          {{- end }}
         {{- with .Values.artifactBackend.extraInitContainers }}
         {{- toYaml . | indent 8 }}
         {{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -564,6 +564,7 @@ artifactBackend:
   # -- The command names to be executed
   commandName:
     migration: artifact-backend-migrate
+    init: artifact-backend-init
     main: artifact-backend
   # -- The path of configuration file for artifact-backend
   configPath: /artifact-backend/config/config.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -337,6 +337,7 @@ services:
       - -c
       - |
         ./artifact-backend-migrate
+        ./artifact-backend-init
         ./artifact-backend
     healthcheck:
       test:
@@ -352,6 +353,8 @@ services:
       pg_sql:
         condition: service_healthy
       mgmt_backend:
+        condition: service_healthy
+      pipeline_backend:
         condition: service_healthy
 
   console:


### PR DESCRIPTION
Because

- We are refactoring the preset pipeline mechanism. The preset pipelines will now be created programmatically by other services instead of being downloaded via the preset pipeline downloader. For example, the preset pipelines used by artifact-backend will be created by artifact-backend itself.

This commit

- adds artifact-backend-init cmd for creating preset pipelines.
