### PR TITLE
chore(minio): do not configure MinIO with root credentials

### DIFF
--- a/charts/core/templates/artifact-backend/configmap.yaml
+++ b/charts/core/templates/artifact-backend/configmap.yaml
@@ -73,8 +73,8 @@ data:
     minio:
       host: {{ template "core.minio" . }}
       port: {{ .Values.artifactBackend.minio.port }}
-      rootuser: {{ .Values.artifactBackend.minio.rootuser }}
-      rootpwd: {{ .Values.artifactBackend.minio.rootpwd }}
+      user: {{ .Values.artifactBackend.minio.user }}
+      password: {{ .Values.artifactBackend.minio.password }}
       bucketname: {{ .Values.artifactBackend.minio.bucketname }}
     mgmtbackend:
       host: {{ template "core.mgmtBackend" . }}

--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -116,8 +116,8 @@ data:
     minio:
       host: {{ template "core.minio" . }}
       port: {{ .Values.modelBackend.minio.port }}
-      rootuser: {{ .Values.modelBackend.minio.rootuser }}
-      rootpwd: {{ .Values.modelBackend.minio.rootpwd }}
+      user: {{ .Values.modelBackend.minio.user }}
+      password: {{ .Values.modelBackend.minio.password }}
       bucketname: {{ .Values.modelBackend.minio.bucketname }}
       secure: {{ .Values.modelBackend.minio.secure }}
 {{- end }}

--- a/charts/core/templates/pipeline-backend/configmap.yaml
+++ b/charts/core/templates/pipeline-backend/configmap.yaml
@@ -114,8 +114,8 @@ data:
     minio:
       host: {{ template "core.minio" . }}
       port: {{ .Values.pipelineBackend.minio.port }}
-      rootuser: {{ .Values.pipelineBackend.minio.rootuser }}
-      rootpwd: {{ .Values.pipelineBackend.minio.rootpwd }}
+      user: {{ .Values.pipelineBackend.minio.user }}
+      password: {{ .Values.pipelineBackend.minio.password }}
       bucketname: {{ .Values.pipelineBackend.minio.bucketname }}
       secure: {{ .Values.pipelineBackend.minio.secure }}
     apigateway:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -457,8 +457,8 @@ pipelineBackend:
       maxUnavailable:
   minio:
     port: 9000
-    rootuser: minioadmin
-    rootpwd: minioadmin
+    user: minioadmin
+    password: minioadmin
     bucketname: instill-ai-vdp
     secure: false
 # -- The configuration of model-backend
@@ -548,8 +548,8 @@ modelBackend:
       maxUnavailable:
   minio:
     port: 9000
-    rootuser: minioadmin
-    rootpwd: minioadmin
+    user: minioadmin
+    password: minioadmin
     bucketname: instill-ai-model
     secure: false
 # -- The configuration of artifact-backend
@@ -618,8 +618,8 @@ artifactBackend:
       maxUnavailable:
   minio:
     port: 9000
-    rootuser: minioadmin
-    rootpwd: minioadmin
+    user: minioadmin
+    password: minioadmin
     bucketname: instill-ai-knowledge-bases
   numberOfWorkers: 20
   blob:


### PR DESCRIPTION
Because

- MinIO config params lead to the conclusion that the root credentials are needed, when any valid user/pass with the right permissions (bucket & object) will be valid.

This commit

- Updates the configuration for the MinIO client.
- Helm charts are modified to match the config changes in:
  - https://github.com/instill-ai/pipeline-backend/pull/977
  - https://github.com/instill-ai/model-backend/pull/729
  - https://github.com/instill-ai/artifact-backend/pull/145
