### PR TITLE
chore(helm): bump artifact db version

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -569,7 +569,7 @@ artifactBackend:
   # -- The path of configuration file for artifact-backend
   configPath: /artifact-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 18
+  dbVersion: 21
   # -- Set the service account to be used, default if left empty
   serviceAccountName: ""
   # -- Mount the service account token


### PR DESCRIPTION
Because

- artifact-backend has new db version

This commit

- bump artifact db version
