### PR TITLE
chore(artifact): log MinIO audit logs

### DIFF
--- a/charts/core/templates/artifact-backend/configmap.yaml
+++ b/charts/core/templates/artifact-backend/configmap.yaml
@@ -20,6 +20,7 @@ data:
         key: /etc/instill-ai/core/ssl/artifact/tls.key
       {{- end }}
       maxdatasize: {{ .Values.maxDataSizeMB }}
+      logminioaudit: {{ .Values.artifactBackend.logMinIOAudit }}
     database:
       username: {{ default (include "core.database.username" .) .Values.database.external.username }}
       password: {{ default (include "core.database.rawPassword" .) .Values.database.external.password }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -621,6 +621,7 @@ artifactBackend:
     user: minioadmin
     password: minioadmin
     bucketname: instill-ai-knowledge-bases
+  logMinIOAudit: true
   numberOfWorkers: 20
   blob:
     hostport: http://localhost:8080


### PR DESCRIPTION
Because

- MinIO audit log webhook needs to be enabled.

This commit

- Add MinIO audit log webhook flag to Helm chart.
