### PR TITLE
chore(artifact): remove MinIO log toggle

### DIFF
--- a/charts/core/templates/artifact-backend/configmap.yaml
+++ b/charts/core/templates/artifact-backend/configmap.yaml
@@ -20,7 +20,6 @@ data:
         key: /etc/instill-ai/core/ssl/artifact/tls.key
       {{- end }}
       maxdatasize: {{ .Values.maxDataSizeMB }}
-      logminioaudit: {{ .Values.artifactBackend.logMinIOAudit }}
     database:
       username: {{ default (include "core.database.username" .) .Values.database.external.username }}
       password: {{ default (include "core.database.rawPassword" .) .Values.database.external.password }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -621,7 +621,6 @@ artifactBackend:
     user: minioadmin
     password: minioadmin
     bucketname: instill-ai-knowledge-bases
-  logMinIOAudit: true
   numberOfWorkers: 20
   blob:
     hostport: http://localhost:8080


### PR DESCRIPTION
Because

- The `logminioaudit` configuration value has been removed from `artifact-backend`.

This commit

- Reverts commit f2c2660d89a81e2208ceb70462039b6d67a8202d.

