### PR TITLE
chore(charts): update README for new domain instill-ai.dev

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - Data
 sources:
   - https://github.com/instill-ai/instill-core
-home: "https://www.instill.tech"
+home: "https://www.instill-ai.dev"
 icon: https://artifacts.instill.tech/imgs/helm-core-logo.png
 maintainers:
   - name: Instill AI LTD

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -22,7 +22,7 @@ The Helm chart of Instill Core
 Once Helm has been set up correctly, add the repo as follows:
 
 ```bash
-helm repo add instill-ai https://helm.instill.tech
+helm repo add instill-ai https://helm.instill-ai.dev
 ```
 
 If you had already added this repo earlier, run `helm repo update` to retrieve

--- a/charts/core/README.md.gotmpl
+++ b/charts/core/README.md.gotmpl
@@ -15,7 +15,7 @@
 Once Helm has been set up correctly, add the repo as follows:
 
 ```bash
-helm repo add instill-ai https://helm.instill.tech
+helm repo add instill-ai https://helm.instill-ai.dev
 ```
 
 If you had already added this repo earlier, run `helm repo update` to retrieve


### PR DESCRIPTION
Because

- we are replacing `helm.instill.tech` with `helm.instill-ai.dev` to cohere the new domain layout

This commit

- update charts' README docs accordingly
