### PR TITLE
chore(pipeline-backend): separate pipeline-backend and pipeline-backend-worker

### DIFF
--- a/charts/core/templates/_helpers.tpl
+++ b/charts/core/templates/_helpers.tpl
@@ -148,6 +148,13 @@ pipeline-backend
   {{- printf "%s-pipeline-backend" (include "core.fullname" .) -}}
 {{- end -}}
 
+{{/*
+pipeline-backend-worker
+*/}}
+{{- define "core.pipelineBackendWorker" -}}
+  {{- printf "%s-pipeline-backend-worker" (include "core.fullname" .) -}}
+{{- end -}}
+
 {{/* pipeline service and container public port */}}
 {{- define "core.pipelineBackend.publicPort" -}}
   {{- printf "8081" -}}

--- a/charts/core/templates/pipeline-backend/deployment.yaml
+++ b/charts/core/templates/pipeline-backend/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -129,28 +130,6 @@ spec:
         {{- toYaml . | indent 8 }}
         {{- end }}
       containers:
-        - name: pipeline-backend-worker
-          image: {{ .Values.pipelineBackend.image.repository }}:{{ .Values.pipelineBackend.image.tag }}
-          imagePullPolicy: {{ .Values.pipelineBackend.image.pullPolicy }}
-          livenessProbe:
-            tcpSocket:
-              port: rpc
-          {{- if .Values.pipelineBackend.containers.pipelineBackendWorker.resources }}
-          resources:
-            {{- toYaml .Values.pipelineBackend.containers.pipelineBackendWorker.resources | nindent 12 }}
-          {{- end }}
-          command: [./{{ .Values.pipelineBackend.commandName.worker }}]
-          env:
-          {{- if .Values.pipelineBackend.extraEnv }}
-            {{- toYaml .Values.pipelineBackend.extraEnv | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: config
-              mountPath: {{ .Values.pipelineBackend.configPath }}
-              subPath: config.yaml
-            {{- with .Values.pipelineBackend.extraVolumeMounts }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
         - name: pipeline-backend
           image: {{ .Values.pipelineBackend.image.repository }}:{{ .Values.pipelineBackend.image.tag }}
           imagePullPolicy: {{ .Values.pipelineBackend.image.pullPolicy }}
@@ -217,6 +196,92 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.pipelineBackend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "core.pipelineBackendWorker" . }}
+  labels:
+    {{- include "core.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pipeline-backend-worker
+  annotations:
+    rollme: {{ randAlphaNum 5 | quote }}
+    {{- with .Values.pipelineBackendWorker.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- else}}
+    rollingUpdate: null
+    {{- end }}
+  {{- if not .Values.pipelineBackendWorker.autoscaling.enabled }}
+  replicas: {{ .Values.pipelineBackendWorker.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "core.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: pipeline-backend-worker
+  template:
+    metadata:
+      labels:
+        {{- include "core.matchLabels" . | nindent 8 }}
+        app.kubernetes.io/component: pipeline-backend-worker
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/pipeline-backend/configmap.yaml") . | sha256sum }}
+        {{- with .Values.pipelineBackendWorker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+      terminationGracePeriodSeconds: 120
+      containers:
+        - name: pipeline-backend-worker
+          image: {{ .Values.pipelineBackend.image.repository }}:{{ .Values.pipelineBackend.image.tag }}
+          imagePullPolicy: {{ .Values.pipelineBackend.image.pullPolicy }}
+          livenessProbe:
+            tcpSocket:
+              port: rpc
+          {{- if .Values.pipelineBackendWorker.resources }}
+          resources:
+            {{- toYaml .Values.pipelineBackendWorker.resources | nindent 12 }}
+          {{- end }}
+          command: ["./{{ .Values.pipelineBackendWorker.commandName.worker }}"]
+          env:
+          {{- if .Values.pipelineBackendWorker.extraEnv }}
+            {{- toYaml .Values.pipelineBackendWorker.extraEnv | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: {{ .Values.pipelineBackendWorker.configPath }}
+              subPath: config.yaml
+            {{- with .Values.pipelineBackendWorker.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "core.pipelineBackendWorker" . }}
+        {{- with .Values.pipelineBackendWorker.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pipelineBackendWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pipelineBackendWorker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/core/templates/pipeline-backend/deployment.yaml
+++ b/charts/core/templates/pipeline-backend/deployment.yaml
@@ -274,6 +274,7 @@ spec:
         {{- with .Values.pipelineBackendWorker.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.pipelineBackendWorker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/core/templates/pipeline-backend/deployment.yaml
+++ b/charts/core/templates/pipeline-backend/deployment.yaml
@@ -262,16 +262,16 @@ spec:
           {{- end }}
           volumeMounts:
             - name: config
-              mountPath: {{ .Values.pipelineBackendWorker.configPath }}
+              mountPath: {{ .Values.pipelineBackend.configPath }}
               subPath: config.yaml
-            {{- with .Values.pipelineBackendWorker.extraVolumeMounts }}
+            {{- with .Values.pipelineBackend.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         - name: config
           configMap:
-            name: {{ template "core.pipelineBackendWorker" . }}
-        {{- with .Values.pipelineBackendWorker.extraVolumes }}
+            name: {{ template "core.pipelineBackend" . }}
+        {{- with .Values.pipelineBackend.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.pipelineBackendWorker.nodeSelector }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -386,7 +386,6 @@ pipelineBackend:
     migration: pipeline-backend-migrate
     init: pipeline-backend-init
     main: pipeline-backend
-    worker: pipeline-backend-worker
   # -- The path of configuration file for pipeline-backend
   configPath: /pipeline-backend/config/config.yaml
   # -- The database migration version
@@ -461,6 +460,39 @@ pipelineBackend:
     password: minioadmin
     bucketname: instill-ai-vdp
     secure: false
+pipelineBackendWorker:
+  # -- Annotation for deployment
+  annotations: {}
+  # -- The command names to be executed
+  commandName:
+    worker: pipeline-backend-worker
+  # -- The path of configuration file for pipeline-backend-worker
+  configPath: /pipeline-backend/config/config.yaml
+  # -- The number of replica for pipeline-backend-worker
+  replicaCount: 1
+  # -- Add extra env variables
+  extraEnv: []
+  # -- Mount external volumes
+  # For example, mount a secret containing Certificate root CA to verify database
+  # TLS connection.
+  extraVolumes: []
+  # - name: my-volume
+  #   secret:
+  #     secretName: my-secret
+  extraVolumeMounts: []
+  # - name: my-volume
+  #   mountPath: /etc/secrets/my-secret
+  #   readOnly: true
+  # -- Additional deployment annotations
+  podAnnotations: {}
+  resources: {}
+  autoscaling:
+    enabled: false
+    minReplicas:
+    maxReplicas:
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 # -- The configuration of model-backend
 modelBackend:
   # -- The image of model-backend


### PR DESCRIPTION
Because

- We have to separate pipeline-backend and pipeline-backend-worker

This commit

- separate pipeline-backend and pipeline-backend-worker
