### PR TITLE
fix(worker): use pipeline server host in pipeline client

### DIFF
--- a/charts/core/templates/pipeline-backend/configmap.yaml
+++ b/charts/core/templates/pipeline-backend/configmap.yaml
@@ -25,6 +25,7 @@ data:
         cert: /etc/instill-ai/vdp/ssl/pipeline/tls.crt
         key: /etc/instill-ai/vdp/ssl/pipeline/tls.key
       {{- end }}
+      instanceid: {{ template "core.pipelineBackend" . }}
     connector:
       instill:
         usestaticmodellist: {{ .Values.pipelineBackend.useStaticModelList }}


### PR DESCRIPTION
Because

- instill-ai/pipeline-backend#989 fixes a bug in the worker initialisation.  This requires the `InstanceID` config value to be set.

This commit

- Adds the `instanceid` value to `pipeline-backend*`'s configmap.
