### PR TITLE
chore(pipeline-backend): create hpa for pipeline-backend-worker

### DIFF
--- a/charts/core/templates/pipeline-backend/deployment.yaml
+++ b/charts/core/templates/pipeline-backend/deployment.yaml
@@ -82,10 +82,6 @@ spec:
         - name: pipeline-backend-migration
           image: {{ .Values.pipelineBackend.image.repository }}:{{ .Values.pipelineBackend.image.tag }}
           imagePullPolicy: {{ .Values.pipelineBackend.image.pullPolicy }}
-          {{- if .Values.pipelineBackend.containers.pipelineBackendWorker.resources }}
-          resources:
-            {{- toYaml .Values.pipelineBackend.containers.pipelineBackend.resources | nindent 12 }}
-          {{- end }}
           command: [./{{ .Values.pipelineBackend.commandName.migration }}]
           volumeMounts:
             - name: config
@@ -98,10 +94,6 @@ spec:
         - name: pipeline-backend-init
           image: {{ .Values.pipelineBackend.image.repository }}:{{ .Values.pipelineBackend.image.tag }}
           imagePullPolicy: {{ .Values.pipelineBackend.image.pullPolicy }}
-          {{- if .Values.pipelineBackend.containers.pipelineBackendWorker.resources }}
-          resources:
-            {{- toYaml .Values.pipelineBackend.containers.pipelineBackendWorker.resources | nindent 12 }}
-          {{- end }}
           command: [./{{ .Values.pipelineBackend.commandName.init }}]
           volumeMounts:
             - name: config
@@ -148,10 +140,6 @@ spec:
             periodSeconds: 10
             initialDelaySeconds: 60
             timeoutSeconds: 10
-          {{- if .Values.pipelineBackend.containers.pipelineBackend.resources }}
-          resources:
-            {{- toYaml .Values.pipelineBackend.containers.pipelineBackend.resources | nindent 12 }}
-          {{- end }}
           command: [./{{ .Values.pipelineBackend.commandName.main }}]
           ports:
             - name: {{ ternary "https" "http" .Values.internalTLS.enabled }}-public

--- a/charts/core/templates/pipeline-backend/hpa.yml
+++ b/charts/core/templates/pipeline-backend/hpa.yml
@@ -3,49 +3,65 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "core.pipelineBackend" . }}
+  labels:
+    {{- include "core.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pipeline-backend
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ template "core.pipelineBackend" . }}
-    labels:
-    {{- include "core.labels" . | nindent 4 }}
-    app.kubernetes.io/component: pipeline-backend
   minReplicas: {{ .Values.pipelineBackend.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.pipelineBackend.autoscaling.maxReplicas }}
   metrics:
-{{- with .Values.pipelineBackend.autoscaling.targetCPUUtilizationPercentage }}
+    {{- with .Values.pipelineBackend.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ . }}
-{{- end }}
-{{- with .Values.pipelineBackend.autoscaling.targetAverageMemoryUtilization }}
+          averageUtilization: {{ .Values.pipelineBackend.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- with .Values.pipelineBackend.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
-          type: AverageValue
-          averageValue: {{ . }}
+          type: Utilization
+          averageUtilization: {{ .Values.pipelineBackend.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
 {{- end }}
-{{- with .Values.pipelineBackend.autoscaling.pipelineBackendWorkerMemoryUtilization }}
-    - type: ContainerResource
-      containerResource:
-        name: memory
-        container: pipeline-backend-worker
+
+{{- if .Values.pipelineBackendWorker.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "core.pipelineBackendWorker" . }}
+  labels:
+    {{- include "core.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pipeline-backend-worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "core.pipelineBackendWorker" . }}
+  minReplicas: {{ .Values.pipelineBackendWorker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.pipelineBackendWorker.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.pipelineBackendWorker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ . }}
-{{- end }}
-{{- with .Values.pipelineBackend.autoscaling.pipelineBackendMemoryUtilization }}
-    - type: ContainerResource
-      containerResource:
+          averageUtilization: {{ .Values.pipelineBackendWorker.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.pipelineBackendWorker.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
         name: memory
-        container: pipeline-backend
         target:
           type: Utilization
-          averageUtilization: {{ . }}
-{{- end }}
+          averageUtilization: {{ .Values.pipelineBackendWorker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
 {{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -435,17 +435,12 @@ pipelineBackend:
   podAnnotations: {}
   # -- Additional service annotations
   serviceAnnotations: {}
-  containers:
-    pipelineBackend:
-      resources: {}
-    pipelineBackendWorker:
-      resources: {}
   autoscaling:
     enabled: false
     minReplicas:
     maxReplicas:
     targetCPUUtilizationPercentage:
-    targetAverageMemoryUtilization:
+    targetMemoryUtilizationPercentage:
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -490,6 +485,8 @@ pipelineBackendWorker:
     enabled: false
     minReplicas:
     maxReplicas:
+    targetCPUUtilizationPercentage:
+    targetMemoryUtilizationPercentage:
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
Because

- We have to create HPA for pipeline-backend-worker
- We have to fix the HPA of pipeline-backend

This commit

- create hpa for pipeline-backend-worker
