### PR TITLE
ci(github): fix the missing variable in Helm integration test

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -148,6 +148,11 @@ jobs:
           kubectl --namespace instill-ai port-forward ${DATABASE_POD_NAME} ${POSTGRESQL_PORT}:${POSTGRESQL_PORT} > /dev/null 2>&1 &
           while ! nc -vz localhost ${API_GATEWAY_PORT} > /dev/null 2>&1; do sleep 5; done
 
+      - name: Uppercase component name
+        id: uppercase
+        run: |
+          echo "COMPONENT_NAME=$(echo ${{ inputs.component }} | tr 'a-z-' 'A-Z_')" >> $GITHUB_OUTPUT
+
       - name: Run ${{ inputs.component }} integration test (${{ inputs.target }})
         env:
           COMPONENT_VERSION: ${{ env[format('{0}_VERSION', steps.uppercase.outputs.COMPONENT_NAME)] }}


### PR DESCRIPTION
Because:

- A step was accidentally removed.

This commit:

- Fixes a missing variable in the Helm integration test.