### PR TITLE
ci(github): add db proxy for integration-test

### DIFF
--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -55,6 +55,9 @@ jobs:
             make latest EDITION=local-ce:test COMPONENT_ENV=.env.component-test
           else
             make all EDITION=local-ce:test COMPONENT_ENV=.env.component-test
+
+            # For testing, we need to expose the pg-sql service to the host machine.
+            docker run -d --network=instill-network --link pg-sql:db -p 5432:5432 alpine/socat tcp-listen:5432,fork,reuseaddr tcp-connect:db:5432
           fi
 
       - name: Uppercase component name


### PR DESCRIPTION
Because

- we need to expose the pg-sql service to the host machine for testing purpose.

This commit

- add db proxy for integration-test
