### PR TITLE
chore(migration): add env in mgmt-backend and artifact-backend's migration container

### DIFF
--- a/charts/core/templates/artifact-backend/deployment.yaml
+++ b/charts/core/templates/artifact-backend/deployment.yaml
@@ -69,6 +69,10 @@ spec:
             {{- toYaml .Values.artifactBackend.resources | nindent 12 }}
           {{- end }}
           command: [./{{ .Values.artifactBackend.commandName.migration }}]
+          {{- if .Values.artifactBackend.extraEnv }}
+          env:
+            {{- toYaml .Values.artifactBackend.extraEnv | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: {{ .Values.artifactBackend.configPath }}
@@ -92,8 +96,8 @@ spec:
             - name: config
               mountPath: {{ .Values.artifactBackend.configPath }}
               subPath: config.yaml
-          env:
           {{- if .Values.artifactBackend.extraEnv }}
+          env:
             {{- toYaml .Values.artifactBackend.extraEnv | nindent 12 }}
           {{- end }}
         {{- with .Values.artifactBackend.extraInitContainers }}

--- a/charts/core/templates/mgmt-backend/deployment.yaml
+++ b/charts/core/templates/mgmt-backend/deployment.yaml
@@ -85,6 +85,10 @@ spec:
             {{- toYaml .Values.mgmtBackend.resources | nindent 12 }}
           {{- end }}
           command: [./{{ .Values.mgmtBackend.commandName.migration }}]
+          {{- if .Values.mgmtBackend.extraEnv }}
+          env:
+            {{- toYaml .Values.mgmtBackend.extraEnv | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: {{ .Values.mgmtBackend.configPath }}

--- a/charts/core/templates/openfga/deployment.yaml
+++ b/charts/core/templates/openfga/deployment.yaml
@@ -77,6 +77,9 @@ spec:
               value: "{{ default (include "core.database.username" .) .Values.database.external.username }}"
             - name: PGPASSWORD
               value: "{{ include "databasePasswordSecret" . | default .Values.database.external.password | default (include "core.database.rawPassword" .) }}"
+          {{- if .Values.openfga.extraEnv }}
+          {{- toYaml .Values.openfga.extraEnv | nindent 12 }}
+          {{- end }} 
         - name: openfga-migration
           image: {{ .Values.openfga.image.repository }}:{{ .Values.openfga.image.tag }}
           imagePullPolicy: {{ .Values.openfga.image.pullPolicy }}

--- a/charts/core/templates/openfga/deployment.yaml
+++ b/charts/core/templates/openfga/deployment.yaml
@@ -77,9 +77,9 @@ spec:
               value: "{{ default (include "core.database.username" .) .Values.database.external.username }}"
             - name: PGPASSWORD
               value: "{{ include "databasePasswordSecret" . | default .Values.database.external.password | default (include "core.database.rawPassword" .) }}"
-          {{- if .Values.openfga.extraEnv }}
-          {{- toYaml .Values.openfga.extraEnv | nindent 12 }}
-          {{- end }} 
+            {{- if .Values.openfga.extraEnv }}
+            {{- toYaml .Values.openfga.extraEnv | nindent 12 }}
+            {{- end }}
         - name: openfga-migration
           image: {{ .Values.openfga.image.repository }}:{{ .Values.openfga.image.tag }}
           imagePullPolicy: {{ .Values.openfga.image.pullPolicy }}
@@ -89,6 +89,9 @@ spec:
               value: postgres
             - name: OPENFGA_DATASTORE_URI
               value: postgres://{{ default (include "core.database.username" .) .Values.database.external.username }}:{{ include "databasePasswordSecret" . | default .Values.database.external.password | default (include "core.database.rawPassword" .) }}@{{ default (include "core.database.host" .) .Values.database.external.host }}:{{ default (include "core.database.port" .) .Values.database.external.port }}/openfga?sslmode=disable
+            {{- if .Values.openfga.extraEnv }}
+            {{- toYaml .Values.openfga.extraEnv | nindent 12 }}
+            {{- end }}
       containers:
         - name: openfga
           image: {{ .Values.openfga.image.repository }}:{{ .Values.openfga.image.tag }}
@@ -113,6 +116,9 @@ spec:
               value: "{{ default (include "core.database.username" .) .Values.database.external.username }}"
             - name: PGPASSWORD
               value: "{{ include "databasePasswordSecret" . | default .Values.database.external.password | default (include "core.database.rawPassword" .) }}"
+            {{- if .Values.openfga.extraEnv }}
+            {{- toYaml .Values.openfga.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -146,6 +152,9 @@ spec:
               value: "{{ default (include "core.database.username" .) .Values.database.external_replica.username }}"
             - name: PGPASSWORD
               value: "{{ include "databasePasswordSecret" . | default .Values.database.external_replica.password | default (include "core.database.rawPassword" .) }}"
+            {{- if .Values.openfga.extraEnv }}
+            {{- toYaml .Values.openfga.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: 8082
               protocol: TCP


### PR DESCRIPTION
Because

- We have to add env in mgmt-backend and artifact-backend's migration container

This commit

- add env in mgmt-backend and artifact-backend's migration container
