### PR TITLE
chore(env): upgrade Ray to 2.44.1

### DIFF
--- a/.env
+++ b/.env
@@ -20,6 +20,9 @@ OBSERVE_ENABLED=false
 # flag to enable model-backend creating pre-deploy models
 INITMODEL_ENABLED=false
 
+# model inventory JSON file path to initialize model-backend with pre-deploy models
+INITMODEL_PATH=
+
 # configuration directory path
 CONFIG_DIR_PATH=./configs
 
@@ -31,7 +34,7 @@ DOCKER_BUILDKIT=1
 COMPOSE_DOCKER_CLI_BUILD=1
 
 # max data size in MB which pipeline-/model-/artifact-backend accept to process
-MAX_DATA_SIZE=12
+MAX_DATA_SIZE=1024
 
 # Alpine version for instill-core Docker image (docker-in-docker operation )
 ALPINE_VERSION=3.21
@@ -88,15 +91,15 @@ CONSOLE_VERSION=0.65.0-beta
 CONSOLE_HOST=console
 CONSOLE_PORT=3000
 
-# Ray Serve
+# Ray
 RAY_IMAGE=instill/ray
 RAY_VERSION=0.5.1-alpha
-RAY_SERVE_HOST=ray
+RAY_HOST=ray
 RAY_CLIENT_PORT=10001
 RAY_DASHBOARD_PORT=8265
 RAY_GCS_PORT=6379
 RAY_SERVE_PORT=8000
-RAY_SERVE_GRPC_PORT=9000
+RAY_GRPC_PORT=9000
 RAY_METRICS_PORT=8080
 RAY_VRAM=
 

--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -26,9 +26,11 @@ jobs:
           remove-docker-images: "true"
           build-mount-path: "/var/lib/docker"
 
+      - name: Restart docker
+        run: sudo service docker restart
+
       - name: Setup Minikube
         run: |
-          sudo service docker restart
           minikube start --cpus 4 --memory 12288
 
       - name: Checkout repo and load .env

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -18,9 +18,13 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          overprovision-lvm: "true"
+          root-reserve-mb: 2048
           remove-dotnet: "true"
-          build-mount-path: "/var/lib/docker/"
+          remove-android: "true"
+          remove-haskell: "true"
+          remove-codeql: "true"
+          remove-docker-images: "true"
+          build-mount-path: "/var/lib/docker"
 
       - name: Restart docker
         run: sudo service docker restart

--- a/charts/core/templates/model-backend/deployment.yaml
+++ b/charts/core/templates/model-backend/deployment.yaml
@@ -128,9 +128,9 @@ spec:
           command: ['sh', '-c']
           args:
           - >
-            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${RAY_SERVE_HOST}:${RAY_SERVE_PORT}/-/routes)" != "200" ]]; do echo waiting for ray; sleep 1; done
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${RAY_HOST}:${RAY_SERVE_PORT}/-/routes)" != "200" ]]; do echo waiting for ray; sleep 1; done
           env:
-            - name: RAY_SERVE_HOST
+            - name: RAY_HOST
               value: "{{ template "core.ray" . }}"
             - name: RAY_SERVE_PORT
               value: "{{ template "core.ray.servePort" . }}"

--- a/charts/core/templates/ray/service.yaml
+++ b/charts/core/templates/ray/service.yaml
@@ -78,7 +78,7 @@ spec:
                 value: http://core-prometheus:9090
               - name: RAY_TASK_MAX_RETRIES
                 value: "2"
-              - name: RAY_worker_register_timeout_seconds
+              - name: RAY_WORKER_REGISTER_TIMEOUT_SECONDS
                 value: "3600"
               # - name: RAY_REDIS_ADDRESS
               #   value: {{ template "core.redis.addr" . }}
@@ -163,7 +163,7 @@ spec:
               env:
                 - name: RAY_TASK_MAX_RETRIES
                   value: "2"
-                - name: RAY_worker_register_timeout_seconds
+                - name: RAY_WORKER_REGISTER_TIMEOUT_SECONDS
                   value: "3600"
               lifecycle:
                 postStart:
@@ -183,7 +183,7 @@ spec:
                           fi;
                           sleep 1;
                         done;
-                        serve start --http-host=0.0.0.0 --grpc-port 9000 --grpc-servicer-functions ray_pb2_grpc.add_RayServiceServicer_to_server
+                        serve start --http-host=0.0.0.0 --grpc-port 9000 --grpc-servicer-functions model_ray_user_defined_pb2_grpc.add_RayUserDefinedServiceServicer_to_server
                 preStop:
                   exec:
                     command: ["/bin/sh","-c","ray stop"]

--- a/docker-compose-latest.yml
+++ b/docker-compose-latest.yml
@@ -106,9 +106,6 @@ services:
       - exclude-pipeline
       - exclude-artifact
     image: ${MODEL_BACKEND_IMAGE}:latest
-    environment:
-      CFG_INITMODEL_ENABLED: ${INITMODEL_ENABLED}
-      CFG_INITMODEL_PATH: https://raw.githubusercontent.com/instill-ai/instill-core/main/model-hub/model_hub_test.json
 
   artifact_backend:
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,7 +225,7 @@ services:
       CFG_SERVER_USAGE_ENABLED: ${USAGE_ENABLED}
       CFG_SERVER_EDITION: ${EDITION}
       CFG_SERVER_INSTILLCOREHOST: http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT}
-      CFG_RAYSERVER_GRPCURI: ${RAY_SERVE_HOST}:${RAY_SERVE_GRPC_PORT}
+      CFG_RAYSERVER_GRPCURI: ${RAY_HOST}:${RAY_GRPC_PORT}
       CFG_RAYSERVER_MODELSTORE: /model-config
       CFG_RAYSERVER_VRAM: ${RAY_VRAM}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
@@ -277,7 +277,7 @@ services:
     restart: unless-stopped
     environment:
       CFG_SERVER_DEBUG: "false"
-      CFG_RAYSERVER_GRPCURI: ${RAY_SERVE_HOST}:${RAY_SERVE_GRPC_PORT}
+      CFG_RAYSERVER_GRPCURI: ${RAY_HOST}:${RAY_GRPC_PORT}
       CFG_RAYSERVER_MODELSTORE: /model-config
       CFG_RAYSERVER_VRAM: ${RAY_VRAM}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
@@ -303,6 +303,8 @@ services:
       MODEL_BACKEND_HOST: ${MODEL_BACKEND_HOST}
       CFG_LOG_EXTERNAL: ${OBSERVE_ENABLED}
       CFG_LOG_OTELCOLLECTOR_PORT: ${OTEL_COLLECTOR_PORT}
+      CFG_INITMODEL_ENABLED: ${INITMODEL_ENABLED}
+      CFG_INITMODEL_PATH: ${INITMODEL_PATH}
     entrypoint: ./model-backend-init-model
     depends_on:
       model_backend:
@@ -417,7 +419,7 @@ services:
         condition: service_healthy
 
   ray:
-    container_name: ${RAY_SERVE_HOST}
+    container_name: ${RAY_HOST}
     image: ${RAY_IMAGE}:${RAY_RELEASE_TAG}
     # for dind podman
     privileged: true
@@ -427,18 +429,20 @@ services:
     environment:
       - RAY_ADDRESS=0.0.0.0:6379
       - RAY_REDIS_ADDRESS=redis:6379
+      - RAY_METRICS_PORT=${RAY_METRICS_PORT}
+      - RAY_GRPC_PORT=${RAY_GRPC_PORT}
       - RAY_GRAFANA_HOST=http://${GRAFANA_HOST}:${GRAFANA_PORT}
       - RAY_PROMETHEUS_HOST=http://${PROMETHEUS_HOST}:${PROMETHEUS_PORT}
       - RAY_GRAFANA_IFRAME_HOST=http://localhost:${GRAFANA_PORT}
       - RAY_ENABLE_CLUSTER_STATUS_LOG=0
-      - RAY_worker_register_timeout_seconds=3600
+      - RAY_WORKER_REGISTER_TIMEOUT_SECONDS=3600
     entrypoint: ["/bin/bash", "-c"]
     command: |
       'if [[ $${NVIDIA_VISIBLE_DEVICES} == all ]]; then
         sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml;
       fi &&
       ray start --head --node-ip-address=0.0.0.0 --dashboard-host=0.0.0.0 --metrics-export-port ${RAY_METRICS_PORT} --disable-usage-stats &&
-      serve start --http-host=0.0.0.0 --grpc-port ${RAY_SERVE_GRPC_PORT} --grpc-servicer-functions ray_pb2_grpc.add_RayServiceServicer_to_server &&
+      serve start --http-host=0.0.0.0 --grpc-port ${RAY_GRPC_PORT} --grpc-servicer-functions model_ray_user_defined_pb2_grpc.add_RayUserDefinedServiceServicer_to_server &&
       tail -f /dev/null'
     volumes:
       - /var/lib/containers:/var/lib/containers
@@ -449,7 +453,7 @@ services:
       interval: 60s
       timeout: 5s
       retries: 2
-    shm_size: 4gb
+    shm_size: 10.24gb
     ports:
       - ${RAY_DASHBOARD_PORT}:${RAY_DASHBOARD_PORT}
 


### PR DESCRIPTION

Because
- Model initialization requires a configurable path for more flexible deployment
- Ray service needs additional shared memory to handle larger model loads
- Simplified variable names improve code readability and maintenance

This commit
- Adds `INITMODEL_PATH` environment variable to configure model initialization location
- Renames `RAY_SERVE_HOST` to `RAY_HOST` and `RAY_SERVE_GRPC_PORT` to `RAY_GRPC_PORT` for consistency
- Updates all relevant deployment scripts to use the new environment variable names
- Increases the shared memory allocation for Ray service to improve performance
- Increases the maximum data payload size to 1GB