### PR TITLE
chore(helm): upgrade kuberay-operator to version 1.3.2

### DIFF
--- a/charts/core/Chart.lock
+++ b/charts/core/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 4.1.30
 - name: kuberay-operator
   repository: https://ray-project.github.io/kuberay-helm/
-  version: 1.1.1
+  version: 1.3.2
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.17.3
@@ -20,5 +20,5 @@ dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 70.3.0
-digest: sha256:7b83c3a08fac3394c5aa6fbacd8382d093e1c029e878fa86583e5d008b8778a2
-generated: "2025-03-27T13:11:40.049425Z"
+digest: sha256:cba040f1033590a03d103d9e58e208a53044d65a67fff78059220e91bfe8303c
+generated: "2025-04-14T22:13:13.566722+01:00"

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
       - milvus
   - name: kuberay-operator
     repository: https://ray-project.github.io/kuberay-helm/
-    version: 1.1.1
+    version: 1.3.2
     tags:
       - ray
   - name: elasticsearch

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -13,7 +13,7 @@ The Helm chart of Instill Core
 | https://jaegertracing.github.io/helm-charts | jaeger | 3.4.1 |
 | https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.119.0 |
 | https://prometheus-community.github.io/helm-charts | kube-prometheus-stack | 70.3.0 |
-| https://ray-project.github.io/kuberay-helm/ | kuberay-operator | 1.1.1 |
+| https://ray-project.github.io/kuberay-helm/ | kuberay-operator | 1.3.2 |
 | https://zilliztech.github.io/milvus-helm/ | milvus | 4.1.30 |
 
 ## Install

--- a/charts/core/templates/_helpers.tpl
+++ b/charts/core/templates/_helpers.tpl
@@ -280,11 +280,11 @@ Temporal
   {{- printf "%s-kuberay-operator" (include "ray.fullname" .) -}}
 {{- end -}}
 
-{{- define "core.ray-service" -}}
+{{- define "core.ray" -}}
   {{- printf "%s-ray" (include "ray.fullname" .) -}}
 {{- end -}}
 
-{{- define "core.ray" -}}
+{{- define "core.rayServiceName" -}}
   {{- printf "%s-ray-head-svc%s" (include "ray.fullname" .) (include "ray.suffix" .) -}}
 {{- end -}}
 

--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -51,7 +51,7 @@ data:
         key: /etc/instill-ai/core/ssl/artifact/tls.key
       {{- end }}
     ray:
-      host: {{ include "core.ray" . }}
+      host: {{ include "core.rayServiceName" . }}
       port:
         grpc: {{ include "core.ray.serveGrpcPort" . }}
         client: {{ include "core.ray.servePort" . }}

--- a/charts/core/templates/ray/configmap.yaml
+++ b/charts/core/templates/ray/configmap.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.tags.ray -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "core.ray" . }}-podman
+data:
+  registries.conf: |
+    unqualified-search-registries = ["{{ template "core.registry" . }}:{{ template "core.registry.port" . }}", "docker.io", "quay.io"]
+
+    [[registry]]
+    location = "{{ template "core.registry" . }}:{{ template "core.registry.port" . }}"
+    insecure = true
+  policy.json: |
+    {
+      "default": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ],
+      "transports": {
+        "docker-daemon": {
+          "": [{ "type": "insecureAcceptAnything" }]
+        }
+      }
+    }
+  storage.conf: |
+    [storage]
+    driver = "overlay"
+{{- end }}

--- a/charts/core/templates/ray/monitor.yaml
+++ b/charts/core/templates/ray/monitor.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: ray-head-monitor
+  name: {{ template "core.ray" . }}
   namespace: instill-ai
   labels:
     # `release: $HELM_RELEASE`: Prometheus can only detect ServiceMonitor with this label.

--- a/charts/core/templates/ray/raycluster.yaml
+++ b/charts/core/templates/ray/raycluster.yaml
@@ -2,7 +2,7 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  name: {{ template "core.ray-service" . }}
+  name: {{ template "core.ray" . }}
   # annotations:
   #   ray.io/ft-enabled: "true"
 spec:
@@ -39,9 +39,9 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         volumes:
-          - name: podman-configmap
+          - name: {{ template "core.ray" . }}-podman
             configMap:
-              name: podman
+              name: {{ template "core.ray" . }}-podman
               defaultMode: 0666
               items:
                 - key: registries.conf
@@ -83,11 +83,11 @@ spec:
               # - name: RAY_REDIS_ADDRESS
               #   value: {{ template "core.redis.addr" . }}
             volumeMounts:
-              - mountPath: /etc/containers/
-                name: podman-configmap
+              - mountPath: /home/ray/.config/containers/
+                name: {{ template "core.ray" . }}-podman
             ports:
               - containerPort: 6379
-                name: gcs-server
+                name: gcs
               - containerPort: {{ include "core.ray.dashboardPort" . }}
                 name: dashboard
               - containerPort: {{ include "core.ray.clientPort" . }}
@@ -95,7 +95,7 @@ spec:
               - containerPort: {{ include "core.ray.servePort" . }}
                 name: serve
               - containerPort: {{ include "core.ray.serveGrpcPort" . }}
-                name: serve-grpc
+                name: grpc
               - containerPort: {{ include "core.ray.metricsPort" . }}
                 name: metrics
               - containerPort: 44217
@@ -117,6 +117,7 @@ spec:
                 exec:
                   command: ["/bin/sh","-c","ray stop"]
   workerGroupSpecs:
+  {{- $root := . }}
   {{- range $workerGroupSpecs := .Values.ray.workerGroupSpecs }}
     - replicas: {{ $workerGroupSpecs.replicas }}
       minReplicas: {{ $workerGroupSpecs.minReplicas }}
@@ -144,15 +145,17 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumes:
-            - name: podman-configmap
+            - name: {{ template "core.ray" $root }}-podman
               configMap:
-                name: podman
+                name: {{ template "core.ray" $root }}-podman
                 defaultMode: 0666
                 items:
                   - key: registries.conf
                     path: registries.conf
                   - key: policy.json
                     path: policy.json
+                  - key: storage.conf
+                    path: storage.conf
           containers:
             - name: ray-worker
               image: {{ $.Values.ray.image.repository }}:{{ $.Values.ray.image.tag }}{{ ternary "-gpu" "" $workerGroupSpecs.gpuWorkerGroup.enabled }}
@@ -183,7 +186,7 @@ spec:
                           fi;
                           sleep 1;
                         done;
-                        serve start --http-host=0.0.0.0 --grpc-port 9000 --grpc-servicer-functions model_ray_user_defined_pb2_grpc.add_RayUserDefinedServiceServicer_to_server
+                        serve start --http-host=0.0.0.0 --grpc-port 9000 --grpc-servicer-functions user_defined_pb2_grpc.add_RayUserDefinedServiceServicer_to_server
                 preStop:
                   exec:
                     command: ["/bin/sh","-c","ray stop"]
@@ -200,35 +203,7 @@ spec:
                 {{- toYaml $workerGroupSpecs.resources | nindent 16 }}
               {{- end }}
               volumeMounts:
-                - mountPath: /etc/containers/
-                  name: podman-configmap
+                - mountPath: /home/ray/.config/containers/
+                  name: {{ template "core.ray" $root }}-podman
   {{- end }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: podman
-data:
-  registries.conf: |
-    unqualified-search-registries = ["{{ template "core.registry" . }}:{{ template "core.registry.port" . }}", "docker.io", "quay.io"]
-
-    [[registry]]
-    location = "{{ template "core.registry" . }}:{{ template "core.registry.port" . }}"
-    insecure = true
-  policy.json: |
-    {
-      "default": [
-        {
-          "type": "insecureAcceptAnything"
-        }
-      ],
-      "transports": {
-        "docker-daemon": {
-          "": [{ "type": "insecureAcceptAnything" }]
-        }
-      }
-    }
-  storage.conf: |
-    [storage]
-    driver = "overlay"
 {{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1,9 +1,9 @@
 ## -- Provide a name in place of core
-nameOverride: ""
+nameOverride:
 ## -- Override the deployment namespace
-namespaceOverride: ""
+namespaceOverride:
 ## -- Provide a name to substitute for the full names of resources
-fullnameOverride: ""
+fullnameOverride:
 # -- The update strategy for deployments with persistent volumes: "RollingUpdate" or "Recreate"
 # Set it as "Recreate" when "RWM" for volumes isn't supported
 updateStrategy:
@@ -715,7 +715,7 @@ console:
 kuberay-operator:
   image:
     repository: quay.io/kuberay/operator
-    tag: v1.1.1
+    tag: v1.3.2
     pullPolicy: IfNotPresent
   fullnameOverride: ""
   watchNamespace:


### PR DESCRIPTION
Because

- KubeRay 1.3.2 includes important bug fixes and performance improvements over previous versions
- Configuration paths needed to be updated to match the new Ray container structure
- Previous podman configuration setup had inconsistent naming conventions

This commit

- Updates kuberay-operator from previous version to 1.3.2
- Changes container mount paths from `/etc/containers/` to `/home/ray/.config/containers/` for clearer precedence.
- Standardizes podman volume and configmap naming using consistent templates
- Removes deprecated service configuration in favor of new approach
