### PR TITLE
chore(dashboard): update tag for KrakenD

### DIFF
--- a/charts/core/grafana-dashboards/api-gateway/for-prometheus.json
+++ b/charts/core/grafana-dashboards/api-gateway/for-prometheus.json
@@ -8488,7 +8488,7 @@
     "refresh": "30s",
     "schemaVersion": 39,
     "tags": [
-        "krakend-ce:2.9.3"
+        "krakend-ce:2.9.4"
     ],
     "templating": {
         "list": [

--- a/configs/grafana/dashboards/api-gateway/for-prometheus.json
+++ b/configs/grafana/dashboards/api-gateway/for-prometheus.json
@@ -8488,7 +8488,7 @@
     "refresh": "30s",
     "schemaVersion": 39,
     "tags": [
-        "krakend-ce:2.9.3"
+        "krakend-ce:2.9.4"
     ],
     "templating": {
         "list": [


### PR DESCRIPTION
Because

- the dashboard tag for KrakenD is outdated.

This commit

- updates tag for KrakenD
