### PR TITLE
chore(artifact): document required OpenAI key in .env.component

### DIFF
--- a/.env.component
+++ b/.env.component
@@ -1,6 +1,9 @@
 # Provide your API key for the AI vendors so that you can set the components up
 # with default credentials.
+
+# OpenAI key is needed for the embedding feature in artifact-backend.
 CFG_COMPONENT_SECRETS_OPENAI_APIKEY=
+
 CFG_COMPONENT_SECRETS_STABILITYAI_APIKEY=
 CFG_COMPONENT_SECRETS_ANTHROPIC_APIKEY=
 CFG_COMPONENT_SECRETS_COHERE_APIKEY=


### PR DESCRIPTION
Because

- The embedding feature in `artifact-backend` requires (for now) a valid
  OpenAI API key.

This commit

- Adds a comment on `.env.component` to signal this dependency.
