### PR TITLE
fix(ray): fix podman fs issue causing deployment hanging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ COMPONENT_TEST_ENV := .env.component-test
 
 .PHONY: all
 all:			## Launch all services with their up-to-date release version
-	@docker inspect --type=image instill/ray:${RAY_RELEASE_TAG} >/dev/null 2>&1 || printf "\033[1;33mINFO:\033[0m This may take a while due to the enormous size of the Ray Serve image, but the image pulling process should be just a one-time effort.\n" && sleep 5
+	@docker inspect --type=image instill/ray:${RAY_RELEASE_TAG} >/dev/null 2>&1 || printf "\033[1;33mINFO:\033[0m This may take a while due to the enormous size of the Ray image, but the image pulling process should be just a one-time effort.\n" && sleep 5
 	@if [ ! -f "$$(echo ${SYSTEM_CONFIG_PATH}/user_uid)" ]; then \
 		mkdir -p ${SYSTEM_CONFIG_PATH} && \
 		uuidgen > ${SYSTEM_CONFIG_PATH}/user_uid; \
@@ -68,7 +68,7 @@ endif
 
 .PHONY: latest
 latest:			## Lunch all dependent services with their latest codebase
-	@docker inspect --type=image instill/ray:${RAY_LATEST_TAG} >/dev/null 2>&1 || printf "\033[1;33mINFO:\033[0m This may take a while due to the enormous size of the Ray Serve image, but the image pulling process should be just a one-time effort.\n" && sleep 5
+	@docker inspect --type=image instill/ray:${RAY_LATEST_TAG} >/dev/null 2>&1 || printf "\033[1;33mINFO:\033[0m This may take a while due to the enormous size of the Ray image, but the image pulling process should be just a one-time effort.\n" && sleep 5
 	@if [ ! -f "$$(echo ${SYSTEM_CONFIG_PATH}/user_uid)" ]; then \
 		mkdir -p ${SYSTEM_CONFIG_PATH} && \
 		uuidgen > ${SYSTEM_CONFIG_PATH}/user_uid; \
@@ -158,7 +158,7 @@ logs:			## Tail all logs with -n 10
 
 .PHONY: pull
 pull:			## Pull all service images
-	@docker inspect --type=image instill/ray:${RAY_VERSION} >/dev/null 2>&1 || printf "\033[1;33mINFO:\033[0m This may take a while due to the enormous size of the Ray Serve image, but the image pulling process should be just a one-time effort.\n" && sleep 5
+	@docker inspect --type=image instill/ray:${RAY_VERSION} >/dev/null 2>&1 || printf "\033[1;33mINFO:\033[0m This may take a while due to the enormous size of the Ray image, but the image pulling process should be just a one-time effort.\n" && sleep 5
 	@EDITION= DEFAULT_USER_UID= docker compose pull
 
 .PHONY: stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -429,10 +429,7 @@ services:
   ray:
     container_name: ${RAY_HOST}
     image: ${RAY_IMAGE}:${RAY_RELEASE_TAG}
-    # for dind podman
-    privileged: true
-    devices:
-      - "/dev/fuse"
+    privileged: true # for dind podman
     restart: unless-stopped
     environment:
       - RAY_ADDRESS=0.0.0.0:6379
@@ -458,7 +455,7 @@ services:
       interval: 60s
       timeout: 5s
       retries: 2
-    shm_size: 10.24gb
+    shm_size: 4gb
     ports:
       - ${RAY_PORT_DASHBOARD}:${RAY_PORT_DASHBOARD}
 


### PR DESCRIPTION
Because

- we are running rootful mode for Podman DinD for containerized application deployment with Ray Serve, `fuse-overayfs` driver is the correct one to use.

This commit

- remove the corresponding docker compose configuration
