### PR TITLE
ci(compose): reverse COMPOSE_PROFILES logic

### DIFF
--- a/.env
+++ b/.env
@@ -1,33 +1,32 @@
-# docker compose project name
+# Docker Compose project name
 COMPOSE_PROJECT_NAME=instill-core
 
-# docker compose profiles to selectively launch components for developing the latest codebase of the specified component.
-# the value can be all, exclude-api-gateway, exclude-mgmt, exclude-pipeline, exclude-model, or exclude-console.
-PROFILE=all
+# Docker Compose profiles to selectively launch components for developing the latest codebase of the specified component.
+PROFILE=api-gateway,mgmt-backend,pipeline-backend,model-backend,artifact-backend,console
 
-# system-wise config path
+# System-wise config path
 SYSTEM_CONFIG_PATH=~/.config/instill
 
-# flag to enable usage collection
+# Flag to enable usage collection
 USAGE_ENABLED=true
 
-# flag to enable observability stack
+# Flag to enable observability stack
 OBSERVE_ENABLED=false
 
-# flag to enable model-backend creating pre-deploy models
+# Flag to enable model-backend creating pre-deploy models
 INITMODEL_ENABLED=false
 
-# model inventory JSON file path to initialize model-backend with pre-deploy models
+# Model inventory JSON file path to initialize model-backend with pre-deploy models
 INITMODEL_PATH=
 
 # Instill Core instance host. Set it with a valid network address (IP or URL) for the console.
 INSTILL_CORE_HOST=localhost
 
-# container build
+# Container build
 DOCKER_BUILDKIT=1
 COMPOSE_DOCKER_CLI_BUILD=1
 
-# max data size in MB which pipeline-/model-/artifact-backend accept to process
+# Maximum data size in MB which pipeline-/model-/artifact-backend accept to process
 MAX_DATA_SIZE=1024
 
 # Alpine version for the compose Docker image (docker-in-docker operation )

--- a/.env
+++ b/.env
@@ -35,6 +35,9 @@ ALPINE_VERSION=3.21
 # Golang version for GitHub Actions workflow env
 GOLANG_VERSION=1.23.7
 
+# Krakend CE version for integration tests
+KRAKEND_CE_VERSION=2.10.0
+
 # K6-related version for integration tests
 K6_VERSION=0.58.0
 XK6_VERSION=0.19.1

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ build-latest:				## Build latest image. Set BUILD_ALL_FROM_SOURCE=true to build 
 			--build-arg XK6_VERSION=${XK6_VERSION} \
 			--build-arg XK6_SQL_VERSION=${XK6_SQL_VERSION} \
 			--build-arg XK6_SQL_POSTGRES_VERSION=${XK6_SQL_POSTGRES_VERSION} \
-			--build-arg CACHE_DATE="$(shell date)" \
+			--build-arg CACHE_DATE="$(shell date +%Y%m%d%H%M%S)" \
 			--target latest \
 			-t ${INSTILL_CORE_IMAGE_NAME}:latest . && \
 		if [ "$(BUILD_ALL_FROM_SOURCE)" = "true" ]; then \

--- a/charts/core/Chart.lock
+++ b/charts/core/Chart.lock
@@ -1,27 +1,27 @@
 dependencies:
-- name: influxdb2
-  repository: https://helm.influxdata.com
-  version: 2.1.1
-- name: milvus
-  repository: https://zilliztech.github.io/milvus-helm
-  version: 4.1.30
-- name: kuberay-operator
-  repository: https://ray-project.github.io/kuberay-helm
-  version: 1.3.2
-- name: ray-cluster
-  repository: https://ray-project.github.io/kuberay-helm
-  version: 1.3.2
-- name: elasticsearch
-  repository: https://helm.elastic.co
-  version: 8.5.1
-- name: jaeger
-  repository: https://jaegertracing.github.io/helm-charts
-  version: 3.4.1
-- name: opentelemetry-collector
-  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.119.0
-- name: kube-prometheus-stack
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 70.3.0
-digest: sha256:88794c7d365f8054f541d840ad013d6693a03c21801b3b2e554f72655089617a
-generated: "2025-05-09T11:29:28.157632+01:00"
+  - name: influxdb2
+    repository: https://helm.influxdata.com
+    version: 2.1.1
+  - name: milvus
+    repository: https://zilliztech.github.io/milvus-helm
+    version: 4.1.30
+  - name: kuberay-operator
+    repository: https://ray-project.github.io/kuberay-helm
+    version: 1.3.2
+  - name: ray-cluster
+    repository: https://ray-project.github.io/kuberay-helm
+    version: 1.3.2
+  - name: elasticsearch
+    repository: https://helm.elastic.co
+    version: 8.5.1
+  - name: jaeger
+    repository: https://jaegertracing.github.io/helm-charts
+    version: 3.4.1
+  - name: opentelemetry-collector
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+    version: 0.119.0
+  - name: kube-prometheus-stack
+    repository: https://prometheus-community.github.io/helm-charts
+    version: 70.3.0
+digest: sha256:b662401f8366ada11466b10678b478f1b552bf973ec5de83b42c4f8001bdc59b
+generated: "2025-05-12T09:59:02.147515+01:00"

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -12,6 +12,7 @@ services:
       context: ./${API_GATEWAY_HOST}
       args:
         SERVICE_NAME: api-gateway
+        KRAKEND_CE_VERSION: ${KRAKEND_CE_VERSION}
 
   mgmt_backend:
     profiles:

--- a/docker-compose-latest.yml
+++ b/docker-compose-latest.yml
@@ -1,24 +1,14 @@
 services:
   api_gateway:
     profiles:
-      - all
-      - exclude-mgmt
-      - exclude-console
-      - exclude-pipeline
-      - exclude-model
-      - exclude-artifact
+      - api-gateway
     image: ${API_GATEWAY_IMAGE}:latest
     environment:
       LOG_LEVEL: DEBUG
 
   mgmt_backend:
     profiles:
-      - all
-      - exclude-api-gateway
-      - exclude-console
-      - exclude-pipeline
-      - exclude-model
-      - exclude-artifact
+      - mgmt-backend
     image: ${MGMT_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -29,12 +19,7 @@ services:
 
   mgmt_backend_worker:
     profiles:
-      - all
-      - exclude-api-gateway
-      - exclude-console
-      - exclude-pipeline
-      - exclude-model
-      - exclude-artifact
+      - mgmt-backend
     image: ${MGMT_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -42,12 +27,7 @@ services:
 
   pipeline_backend:
     profiles:
-      - all
-      - exclude-api-gateway
-      - exclude-mgmt
-      - exclude-console
-      - exclude-model
-      - exclude-artifact
+      - pipeline-backend
     image: ${PIPELINE_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -58,12 +38,7 @@ services:
 
   pipeline_backend_worker:
     profiles:
-      - all
-      - exclude-api-gateway
-      - exclude-mgmt
-      - exclude-console
-      - exclude-model
-      - exclude-artifact
+      - pipeline-backend
     image: ${PIPELINE_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -71,24 +46,14 @@ services:
 
   model_backend_worker:
     profiles:
-      - all
-      - exclude-api-gateway
-      - exclude-mgmt
-      - exclude-console
-      - exclude-pipeline
-      - exclude-artifact
+      - model-backend
     image: ${MODEL_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
 
   model_backend:
     profiles:
-      - all
-      - exclude-api-gateway
-      - exclude-mgmt
-      - exclude-console
-      - exclude-pipeline
-      - exclude-artifact
+      - model-backend
     image: ${MODEL_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -99,22 +64,12 @@ services:
 
   model_backend_init_model:
     profiles:
-      - all
-      - exclude-api-gateway
-      - exclude-mgmt
-      - exclude-console
-      - exclude-pipeline
-      - exclude-artifact
+      - model-backend
     image: ${MODEL_BACKEND_IMAGE}:latest
 
   artifact_backend:
     profiles:
-      - all
-      - exclude-api-gateway
-      - exclude-mgmt
-      - exclude-console
-      - exclude-pipeline
-      - exclude-model
+      - artifact-backend
     image: ${ARTIFACT_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -125,12 +80,7 @@ services:
 
   console:
     profiles:
-      - all
-      - exclude-api-gateway
-      - exclude-mgmt
-      - exclude-pipeline
-      - exclude-model
-      - exclude-artifact
+      - console
     image: ${CONSOLE_IMAGE}:latest
     environment:
       NEXT_PUBLIC_USAGE_COLLECTION_ENABLED: ${USAGE_ENABLED}


### PR DESCRIPTION
Because

- the dependency between Instill Core backends is getting complex, excluding a service might cause the entire suite spun up failure.

This commit

- reverse the logic to exhaustively specify services to spin up.
