### PR TITLE
ci(composes): increase the healthcheck retries value

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
         ]
       interval: 5s
       timeout: 3s
-      retries: 3
+      retries: 10
       start_period: 10s
     depends_on:
       influxdb:
@@ -105,7 +105,7 @@ services:
         ]
       interval: 5s
       timeout: 3s
-      retries: 3
+      retries: 10
       start_period: 15s
     depends_on:
       temporal:
@@ -196,7 +196,7 @@ services:
         ]
       interval: 5s
       timeout: 3s
-      retries: 3
+      retries: 10
       start_period: 10s
     depends_on:
       pg_sql:
@@ -344,7 +344,7 @@ services:
         ]
       interval: 5s
       timeout: 3s
-      retries: 3
+      retries: 10
       start_period: 10s
     depends_on:
       pg_sql:
@@ -425,7 +425,7 @@ services:
       test: ["CMD-SHELL", "tctl --address temporal:7233 cluster health"]
       interval: 5s
       timeout: 3s
-      retries: 3
+      retries: 10
       start_period: 20s
     depends_on:
       pg_sql:
@@ -486,7 +486,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
       timeout: 3s
-      retries: 3
+      retries: 10
       start_period: 20s
 
   redis:
@@ -499,7 +499,7 @@ services:
       test: ["CMD-SHELL", "redis-cli --raw incr ping"]
       interval: 5s
       timeout: 3s
-      retries: 3
+      retries: 10
       start_period: 5s
 
   elasticsearch:
@@ -540,7 +540,7 @@ services:
         ["CMD-SHELL", "curl -f http://${INFLUXDB_HOST}:${INFLUXDB_PORT}/health"]
       interval: 5s
       timeout: 3s
-      retries: 3
+      retries: 10
       start_period: 10s
 
   openfga_migrate:
@@ -593,7 +593,7 @@ services:
         ]
       interval: 5s
       timeout: 3s
-      retries: 3
+      retries: 10
       start_period: 15s
 
   minio:


### PR DESCRIPTION
Because

- when the host compute resource is packed, the spin-up time can take longer than usual

This commit

- increase the Docker Compose service healthcheck retries value
