### PR TITLE
chore(readme): update domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Please visit our [official documentation](https://www.instill-ai.dev/docs?utm_so
 
 Additional resources:
 
-- [API Reference](https://openapi.instill.tech)
+- [API Reference](https://openapi.instill-ai.dev)
 - [Cookbooks](https://github.com/instill-ai/cookbook)
 - [Tutorials](https://www.instill-ai.dev/blog)
 - [Examples](https://www.instill-ai.dev/docs/examples)

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
 sources:
   - https://github.com/instill-ai/instill-core
 home: "https://www.instill-ai.dev"
-icon: https://artifacts.instill.tech/imgs/helm-core-logo.png
+icon: https://artifacts.instill-ai.com/imgs/helm-core-logo.png
 maintainers:
   - name: Instill AI LTD
     url: https://github.com/instill-ai


### PR DESCRIPTION
This commit

- updates domain name to `instill-ai.dev` and `instill-ai.com`
