### PR TITLE
chore(docker-compose): expose registry port

### DIFF
--- a/docker-compose-latest.yml
+++ b/docker-compose-latest.yml
@@ -125,10 +125,6 @@ services:
     ports:
       - ${OPENFGA_HOST_PORT}:${OPENFGA_PORT}
 
-  registry:
-    ports:
-      - ${REGISTRY_HOST_PORT}:${REGISTRY_PORT}
-
   minio:
     ports:
       - ${MINIO_HOST_PORT}:${MINIO_PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -571,6 +571,8 @@ services:
     container_name: ${REGISTRY_HOST}
     image: ${REGISTRY_IMAGE}:${REGISTRY_VERSION}
     restart: unless-stopped
+    ports:
+      - ${REGISTRY_HOST_PORT}:${REGISTRY_PORT}
     volumes:
       - ${CONFIG_DIR_PATH}/registry/config.yaml:/etc/docker/registry/config.yml
     depends_on:


### PR DESCRIPTION
Because

- the registry port should be always exposed to let user push images.

This commit

- exposes registry port
