### PR TITLE
chore(catalog): add converting pipelines to database model

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -647,7 +647,7 @@ artifactBackend:
   # -- The path of configuration file for artifact-backend
   configPath: /artifact-backend/config/config.yaml
   # -- The database migration version
-  dbVersion: 21
+  dbVersion: 22
   # -- Set the service account to be used, default if left empty
   serviceAccountName: ""
   # -- Mount the service account token


### PR DESCRIPTION
This commit

- Bumps the database version to use migration in instill-ai/artifact-backend#197
