### PR TITLE
ci(compose): improve logics and flows

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Launch Instill Core (${{ needs.determine-target.outputs.target }})
         run: |
           if [ "${{ needs.determine-target.outputs.target }}" == "latest" ]; then
-            make latest EDITION=local-ce:test
+            make latest EDITION=docker-ce:test
           elif [ "${{ needs.determine-target.outputs.target }}" == "all" ]; then
-            make all EDITION=local-ce:test
+            make all EDITION=docker-ce:test
           else
             echo "Invalid target: ${{ needs.determine-target.outputs.target }}"
             exit 1

--- a/Makefile.helper
+++ b/Makefile.helper
@@ -10,7 +10,7 @@ endef
 
 # Function to get common compose parameters
 define GET_COMPOSE_PARAMS
-	$(if $(filter true,$(CI)),EDITION=local-ce:test,EDITION=$${EDITION:=local-ce}) \
+	$(if $(filter true,$(CI)),EDITION=docker-ce:test,EDITION=$${EDITION:=local-ce}) \
 	DEFAULT_USER_UID=$$(cat ${SYSTEM_CONFIG_PATH}/user_uid) \
 	$(if $(filter true,$(CI)),ENV_SECRETS_COMPONENT=${ENV_SECRETS_COMPONENT_TEST},ENV_SECRETS_COMPONENT=${ENV_SECRETS_COMPONENT}) \
 	$(if $(filter latest,$(1)),RAY_LATEST_TAG=${RAY_LATEST_TAG},RAY_RELEASE_TAG=${RAY_RELEASE_TAG})
@@ -32,7 +32,7 @@ define HELM
 	@cd charts/core && helm dependency update
 	@helm install ${HELM_RELEASE_NAME} charts/core \
 		--namespace ${HELM_NAMESPACE} --create-namespace \
-		--set edition=k8s-ce:$(1) \
+		--set edition=$(if $(filter true,$(2)),k8s-ce:test,$(if $(filter latest,$(1)),k8s-ce:latest,k8s-ce)) \
 		--set apiGateway.image.tag=$(if $(filter latest,$(1)),latest,${API_GATEWAY_VERSION}) \
 		--set mgmtBackend.image.tag=$(if $(filter latest,$(1)),latest,${MGMT_BACKEND_VERSION}) \
 		--set mgmtBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
@@ -121,18 +121,9 @@ define REMOVE_HELM_RESOURCES
 	fi
 endef
 
-# Function to run model deployment integration test
-define MODEL_INTEGRATION_TEST
-	@$(MAKE) $(1) EDITION=local-ce:test
-	@$(MAKE) build-and-push-models
-	@$(MAKE) $(1) EDITION=local-ce:test INITMODEL_ENABLED=true INITMODEL_PATH=${PWD}/integration-test/models/inventory.json
-	@$(MAKE) wait-models-deploy
-	@$(MAKE) down
-endef
-
 # Function to run backend integration test
 define COMPOSE_INTEGRATION_TEST
-	@$(MAKE) $(1) EDITION=local-ce:test ENV_SECRETS_COMPONENT=${ENV_SECRETS_COMPONENT_TEST}
+	@$(MAKE) $(1) EDITION=docker-ce:test ENV_SECRETS_COMPONENT=${ENV_SECRETS_COMPONENT_TEST}
 	@docker run --rm \
 		--network ${COMPOSE_NETWORK_NAME} \
 		--name ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}-$(2) \
@@ -178,5 +169,14 @@ define HELM_INTEGRATION_TEST
 			/bin/sh -c 'cd model-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' \
 		"; \
 	fi
+	@$(MAKE) down
+endef
+
+# Function to run model deployment integration test
+define MODEL_INTEGRATION_TEST
+	@EDITION=docker-ce:test docker compose up registry -d
+	@$(MAKE) build-and-push-models
+	@$(MAKE) $(1) EDITION=docker-ce:test INITMODEL_ENABLED=true INITMODEL_PATH=${PWD}/integration-test/models/inventory.json
+	@$(MAKE) wait-models-deploy
 	@$(MAKE) down
 endef

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -254,8 +254,6 @@ services:
       retries: 10
       start_period: 15s
     depends_on:
-      model_backend_worker:
-        condition: service_started
       ray:
         condition: service_healthy
       temporal:
@@ -287,6 +285,8 @@ services:
       CFG_LOG_OTELCOLLECTOR_PORT: ${OTEL_COLLECTOR_PORT}
     entrypoint: ./model-backend-worker
     depends_on:
+      model_backend:
+        condition: service_healthy
       temporal:
         condition: service_healthy
 
@@ -317,7 +317,7 @@ services:
       CFG_SERVER_DEBUG: "false"
       CFG_SERVER_USAGE_ENABLED: ${USAGE_ENABLED}
       CFG_SERVER_EDITION: ${EDITION}
-      CFG_SERVER_DEFAULTUSERUID: ${DEFAULT_USER_UID}
+      CFG_SERVER_DEFAULTUSERUID: ${DEFAULT_USER_UID:-""}
       CFG_SERVER_INSTILLCOREHOST: http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT}
       CFG_PIPELINEBACKEND_HOST: ${PIPELINE_BACKEND_HOST}
       CFG_PIPELINEBACKEND_PUBLICPORT: ${PIPELINE_BACKEND_PUBLICPORT}
@@ -449,8 +449,7 @@ services:
     privileged: true # for dind podman
     restart: unless-stopped
     environment:
-      - RAY_ADDRESS=0.0.0.0:6379
-      - RAY_REDIS_ADDRESS=redis:6379
+      - RAY_REDIS_ADDRESS=${REDIS_HOST}:${REDIS_PORT}
       - RAY_GRAFANA_HOST=http://${GRAFANA_HOST}:${GRAFANA_PORT}
       - RAY_PROMETHEUS_HOST=http://${PROMETHEUS_HOST}:${PROMETHEUS_PORT}
       - RAY_GRAFANA_IFRAME_HOST=http://${GRAFANA_IFRAME_HOST}:${GRAFANA_HOST_PORT}
@@ -519,7 +518,7 @@ services:
     healthcheck:
       test:
         ["CMD-SHELL", "curl -f http://localhost:9200/_cluster/health || exit 1"]
-      interval: 5s
+      interval: 10s
       timeout: 3s
       retries: 10
       start_period: 50s


### PR DESCRIPTION
- The new usage server uses `docker-ce` and `k8s-ce` for different deployment editions.
- The model integration test can have the registry spun up first, followed by the model build and push, then the entire core suite boosted up.
