### PR TITLE
docs(CONTRIBUTING): update guideline

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing Guidelines
 
 We appreciate your contribution to this amazing project! Any form of engagement is welcome, including but not limiting to
+
 - feature request
 - documentation wording
 - bug report
@@ -9,31 +10,34 @@ We appreciate your contribution to this amazing project! Any form of engagement 
 
 ## Development and codebase contribution
 
-Before delving into the details to come up with your first PR, please familiarise yourself with the project structure of 🔮 [**Instill Core**](https://github.com/instill-ai/instill-core).
+Before delving into the details to come up with your first PR, please familiarize yourself with the project structure of 🔮 [**Instill Core**](https://github.com/instill-ai/instill-core).
 
 ### Prerequisites
 
-Please refer to [here](../README.md#prerequisites) to make sure your environment has been all set.
+Please refer to [prerequisites section](../README.md#prerequisites) to make sure your environment has been all set.
 
 ### Launch the local dev system
 
 Clone the repo and launch the `latest` version of the codebase for all dependencies:
 
-```bash
-$ git clone https://github.com/instill-ai/instill-core.git && cd instill-core
+```shell
+git clone https://github.com/instill-ai/instill-core.git && cd instill-core
 
 # launch all latest service components
-$ make latest PROFILE=all
+make latest
 ```
 
-The env variable `PROFILE` is intended to specify which service component you want to develop on
-- `all`
+The `latest` target comes along with an env variable `PROFILE` which is intended to specify which service component you want to develop on. Available options are:
 
-  When you set `PROFILE=all`, the whole **🔮 Instill Core** stack will be launched, meaning you want to test the system as a whole.
+- `api-gateway`
+- `mgmt`
+- `pipeline`
+- `model`
+- `artifact`
+- `console`
 
-- `{service}`
-
-  When you set `PROFILE=exclude-{service}`, in which `{service}` can be  `pipeline`, it means you want to develop on that particular service. The `make` command will launch the corresponding stack **WITHOUT** that service component and **WITH** all other dependent services. Given that, you can later on spin up and down the `{service}` in your dev container. Please take the [pipeline-backend](https://github.com/instill-ai/pipeline-backend#local-dev) as an example.
+When you set `PROFILE={service}`, it means you want to launch that particular services. By default, `PROFILE=api-gateway,mgmt,pipeline,model,artifact,console`.
+You can later on spin up and down the developed service in its dev container. Please take the [pipeline-backend](https://github.com/instill-ai/pipeline-backend/blob/main/.github/CONTRIBUTING.md#local-development) as an example.
 
 #### Component environment variables
 
@@ -54,18 +58,19 @@ receive the OAuth configuration values.
 ### Tear down the local dev system
 
 Simply run:
-```bash
-$ make down
+
+```shell
+make down
 ```
 
 ### Build the local images
 
-We use Docker multi-stage builds to build a `instill/core:{latest,release}` image which will be based on to run dind (docker-in-docker) to build all the images of **🔮 Instill Core** defined in the compose file [docker-compose-build.yml](../docker-compose-build.yml).
+We use Docker multi-stage builds to create `instill/instill-core:{latest,release}` images, which utilize Docker-in-Docker (dind) to build all the images of **🔮 Instill Core** defined in the [docker-compose-build.yml](../docker-compose-build.yml) compose file.
 
 You can build the images by simply running:
 
-```bash
-$ make build-{latest,release}
+```shell
+make build-{latest,release}
 ```
 
 ### Sending PRs


### PR DESCRIPTION
Because

- the `CONTRIBUTING.md` content is out-dated

This commit

- updated the document
