### PR TITLE
ci(compose): adopt short commit hash for all service versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,37 @@ RUN echo "Instill Core latest codebase cloned on ${CACHE_DATE}"
 
 WORKDIR /instill-core
 
-RUN git clone --depth=1 https://github.com/instill-ai/artifact-backend.git
+ARG API_GATEWAY_COMMIT_SHORT_HASH
+ARG PIPELINE_BACKEND_COMMIT_SHORT_HASH
+ARG ARTIFACT_BACKEND_COMMIT_SHORT_HASH
+ARG MODEL_BACKEND_COMMIT_SHORT_HASH
+ARG MGMT_BACKEND_COMMIT_SHORT_HASH
+ARG CONSOLE_COMMIT_SHORT_HASH
+
 RUN git clone --depth=1 https://github.com/instill-ai/api-gateway.git
-RUN git clone --depth=1 https://github.com/instill-ai/mgmt-backend.git
-RUN git clone --depth=1 https://github.com/instill-ai/console.git
+RUN cd api-gateway && git config advice.detachedHead false && git fetch origin && git checkout ${API_GATEWAY_COMMIT_SHORT_HASH}
+
 RUN git clone --depth=1 https://github.com/instill-ai/pipeline-backend.git
+RUN cd pipeline-backend && git config advice.detachedHead false && git fetch origin && git checkout ${PIPELINE_BACKEND_COMMIT_SHORT_HASH}
+
+RUN git clone --depth=1 https://github.com/instill-ai/artifact-backend.git
+RUN cd artifact-backend && git config advice.detachedHead false && git fetch origin && git checkout ${ARTIFACT_BACKEND_COMMIT_SHORT_HASH}
+
 RUN git clone --depth=1 https://github.com/instill-ai/model-backend.git
+RUN cd model-backend && git config advice.detachedHead false && git fetch origin && git checkout ${MODEL_BACKEND_COMMIT_SHORT_HASH}
+
+RUN git clone --depth=1 https://github.com/instill-ai/mgmt-backend.git
+RUN cd mgmt-backend && git config advice.detachedHead false && git fetch origin && git checkout ${MGMT_BACKEND_COMMIT_SHORT_HASH}
+
+RUN git clone --depth=1 https://github.com/instill-ai/console.git
+RUN cd console && git config advice.detachedHead false && git fetch origin && git checkout ${CONSOLE_COMMIT_SHORT_HASH}
+
+ENV API_GATEWAY_VERSION=${API_GATEWAY_COMMIT_SHORT_HASH}
+ENV PIPELINE_BACKEND_VERSION=${PIPELINE_BACKEND_COMMIT_SHORT_HASH}
+ENV ARTIFACT_BACKEND_VERSION=${ARTIFACT_BACKEND_COMMIT_SHORT_HASH}
+ENV MODEL_BACKEND_VERSION=${MODEL_BACKEND_COMMIT_SHORT_HASH}
+ENV MGMT_BACKEND_VERSION=${MGMT_BACKEND_COMMIT_SHORT_HASH}
+ENV CONSOLE_VERSION=${CONSOLE_COMMIT_SHORT_HASH}
 
 FROM alpine:${ALPINE_VERSION} AS release
 
@@ -50,10 +75,23 @@ RUN echo "Instill Core release codebase cloned on ${CACHE_DATE}"
 
 WORKDIR /instill-core
 
-ARG API_GATEWAY_VERSION MGMT_BACKEND_VERSION CONSOLE_VERSION PIPELINE_BACKEND_VERSION MODEL_BACKEND_VERSION ARTIFACT_BACKEND_VERSION
+ARG API_GATEWAY_VERSION
+ARG PIPELINE_BACKEND_VERSION
+ARG ARTIFACT_BACKEND_VERSION
+ARG MODEL_BACKEND_VERSION
+ARG MGMT_BACKEND_VERSION
+ARG CONSOLE_VERSION
+
 RUN git clone --depth=1 -b v${API_GATEWAY_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/api-gateway.git
+RUN git clone --depth=1 -b v${PIPELINE_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/pipeline-backend.git
+RUN git clone --depth=1 -b v${ARTIFACT_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/artifact-backend.git
+RUN git clone --depth=1 -b v${MODEL_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/model-backend.git
 RUN git clone --depth=1 -b v${MGMT_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/mgmt-backend.git
 RUN git clone --depth=1 -b v${CONSOLE_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/console.git
-RUN git clone --depth=1 -b v${PIPELINE_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/pipeline-backend.git
-RUN git clone --depth=1 -b v${MODEL_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/model-backend.git
-RUN git clone --depth=1 -b v${ARTIFACT_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/artifact-backend.git
+
+ENV API_GATEWAY_VERSION=${API_GATEWAY_VERSION}
+ENV PIPELINE_BACKEND_VERSION=${PIPELINE_BACKEND_VERSION}
+ENV ARTIFACT_BACKEND_VERSION=${ARTIFACT_BACKEND_VERSION}
+ENV MODEL_BACKEND_VERSION=${MODEL_BACKEND_VERSION}
+ENV MGMT_BACKEND_VERSION=${MGMT_BACKEND_VERSION}
+ENV CONSOLE_VERSION=${CONSOLE_VERSION}

--- a/Makefile.helper
+++ b/Makefile.helper
@@ -70,11 +70,19 @@ define BUILD
 			--build-arg XK6_SQL_VERSION=${XK6_SQL_VERSION} \
 			--build-arg XK6_SQL_POSTGRES_VERSION=${XK6_SQL_POSTGRES_VERSION} \
 			--build-arg CACHE_DATE="$(if $(filter latest,$(1)),$(shell date +%Y%m%d%H%M%S),$(shell date))" \
-			$(if $(filter release,$(1)),--build-arg API_GATEWAY_VERSION=${API_GATEWAY_VERSION} \
-			--build-arg MGMT_BACKEND_VERSION=${MGMT_BACKEND_VERSION} \
+			$(if $(filter latest,$(1)), \
+			--build-arg API_GATEWAY_COMMIT_SHORT_HASH=$(shell git ls-remote https://github.com/instill-ai/api-gateway.git HEAD | cut -c1-7) \
+			--build-arg PIPELINE_BACKEND_COMMIT_SHORT_HASH=$(shell git ls-remote https://github.com/instill-ai/pipeline-backend.git HEAD | cut -c1-7) \
+			--build-arg ARTIFACT_BACKEND_COMMIT_SHORT_HASH=$(shell git ls-remote https://github.com/instill-ai/artifact-backend.git HEAD | cut -c1-7) \
+			--build-arg MODEL_BACKEND_COMMIT_SHORT_HASH=$(shell git ls-remote https://github.com/instill-ai/model-backend.git HEAD | cut -c1-7) \
+			--build-arg MGMT_BACKEND_COMMIT_SHORT_HASH=$(shell git ls-remote https://github.com/instill-ai/mgmt-backend.git HEAD | cut -c1-7) \
+			--build-arg CONSOLE_COMMIT_SHORT_HASH=$(shell git ls-remote https://github.com/instill-ai/console.git HEAD | cut -c1-7)) \
+			$(if $(filter release,$(1)), \
+			--build-arg API_GATEWAY_VERSION=${API_GATEWAY_VERSION} \
 			--build-arg PIPELINE_BACKEND_VERSION=${PIPELINE_BACKEND_VERSION} \
-			--build-arg MODEL_BACKEND_VERSION=${MODEL_BACKEND_VERSION} \
 			--build-arg ARTIFACT_BACKEND_VERSION=${ARTIFACT_BACKEND_VERSION} \
+			--build-arg MODEL_BACKEND_VERSION=${MODEL_BACKEND_VERSION} \
+			--build-arg MGMT_BACKEND_VERSION=${MGMT_BACKEND_VERSION} \
 			--build-arg CONSOLE_VERSION=${CONSOLE_VERSION}) \
 			--target $(1) \
 			-t ${INSTILL_CORE_IMAGE_NAME}:$(1) . && \

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -7,6 +7,7 @@ services:
       context: ./${API_GATEWAY_HOST}
       args:
         SERVICE_NAME: api-gateway
+        SERVICE_VERSION: ${API_GATEWAY_VERSION}
         KRAKEND_CE_VERSION: ${KRAKEND_CE_VERSION}
 
   pipeline_backend:
@@ -17,33 +18,7 @@ services:
       context: ./${PIPELINE_BACKEND_HOST}
       args:
         SERVICE_NAME: ${PIPELINE_BACKEND_HOST}
-        SERVICE_VERSION: ${PIPELINE_BACKEND_IMAGE}
-
-  model_backend:
-    profiles:
-      - model
-    image: ${MODEL_BACKEND_IMAGE}:${MODEL_BACKEND_VERSION}
-    build:
-      context: ./${MODEL_BACKEND_HOST}
-      args:
-        SERVICE_NAME: ${MODEL_BACKEND_HOST}
-        SERVICE_VERSION: ${MODEL_BACKEND_IMAGE}
-
-  console:
-    profiles:
-      - console
-    image: ${CONSOLE_IMAGE}:${CONSOLE_VERSION}
-    build:
-      context: ./${CONSOLE_HOST}
-
-  mgmt_backend:
-    profiles:
-      - mgmt
-    image: ${MGMT_BACKEND_IMAGE}:${MGMT_BACKEND_VERSION}
-    build:
-      context: ./${MGMT_BACKEND_HOST}
-      args:
-        SERVICE_NAME: ${MGMT_BACKEND_HOST}
+        SERVICE_VERSION: ${PIPELINE_BACKEND_VERSION}
 
   artifact_backend:
     profiles:
@@ -53,3 +28,34 @@ services:
       context: ./${ARTIFACT_BACKEND_HOST}
       args:
         SERVICE_NAME: ${ARTIFACT_BACKEND_HOST}
+        SERVICE_VERSION: ${ARTIFACT_BACKEND_VERSION}
+
+  model_backend:
+    profiles:
+      - model
+    image: ${MODEL_BACKEND_IMAGE}:${MODEL_BACKEND_VERSION}
+    build:
+      context: ./${MODEL_BACKEND_HOST}
+      args:
+        SERVICE_NAME: ${MODEL_BACKEND_HOST}
+        SERVICE_VERSION: ${MODEL_BACKEND_VERSION}
+
+  mgmt_backend:
+    profiles:
+      - mgmt
+    image: ${MGMT_BACKEND_IMAGE}:${MGMT_BACKEND_VERSION}
+    build:
+      context: ./${MGMT_BACKEND_HOST}
+      args:
+        SERVICE_NAME: ${MGMT_BACKEND_HOST}
+        SERVICE_VERSION: ${MGMT_BACKEND_VERSION}
+
+  console:
+    profiles:
+      - console
+    image: ${CONSOLE_IMAGE}:${CONSOLE_VERSION}
+    build:
+      context: ./${CONSOLE_HOST}
+      args:
+        SERVICE_NAME: ${CONSOLE_HOST}
+        SERVICE_VERSION: ${CONSOLE_VERSION}


### PR DESCRIPTION
Because

- the current build-time backend versioning logic is wrong.

This commit

- fixed the versioning logic and assigned short commit hash to all backend services.
