### PR TITLE
ci(compose): add pull_policy: always

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ volumes:
 
 services:
   api_gateway:
+    pull_policy: always
     container_name: ${API_GATEWAY_HOST}
     image: ${API_GATEWAY_IMAGE}:${API_GATEWAY_VERSION}
     restart: unless-stopped
@@ -55,6 +56,7 @@ services:
         condition: service_healthy
 
   pipeline_backend:
+    pull_policy: always
     container_name: ${PIPELINE_BACKEND_HOST}
     image: ${PIPELINE_BACKEND_IMAGE}:${PIPELINE_BACKEND_VERSION}
     restart: unless-stopped
@@ -118,6 +120,7 @@ services:
         condition: service_started
 
   pipeline_backend_worker:
+    pull_policy: always
     container_name: ${PIPELINE_BACKEND_HOST}-worker
     image: ${PIPELINE_BACKEND_IMAGE}:${PIPELINE_BACKEND_VERSION}
     restart: unless-stopped
@@ -158,6 +161,7 @@ services:
         condition: service_healthy
 
   artifact_backend:
+    pull_policy: always
     container_name: ${ARTIFACT_BACKEND_HOST}
     image: ${ARTIFACT_BACKEND_IMAGE}:${ARTIFACT_BACKEND_VERSION}
     restart: unless-stopped
@@ -211,6 +215,7 @@ services:
         condition: service_healthy
 
   model_backend:
+    pull_policy: always
     container_name: ${MODEL_BACKEND_HOST}
     image: ${MODEL_BACKEND_IMAGE}:${MODEL_BACKEND_VERSION}
     restart: unless-stopped
@@ -272,6 +277,7 @@ services:
         condition: service_healthy
 
   model_backend_worker:
+    pull_policy: always
     container_name: ${MODEL_BACKEND_HOST}-worker
     image: ${MODEL_BACKEND_IMAGE}:${MODEL_BACKEND_VERSION}
     restart: unless-stopped
@@ -295,6 +301,7 @@ services:
         condition: service_healthy
 
   model_backend_init_model:
+    pull_policy: always
     container_name: ${MODEL_BACKEND_HOST}-init-model
     image: ${MODEL_BACKEND_IMAGE}:${MODEL_BACKEND_VERSION}
     restart: on-failure
@@ -312,6 +319,7 @@ services:
         condition: service_healthy
 
   mgmt_backend:
+    pull_policy: always
     container_name: ${MGMT_BACKEND_HOST}
     image: ${MGMT_BACKEND_IMAGE}:${MGMT_BACKEND_VERSION}
     restart: unless-stopped
@@ -361,6 +369,7 @@ services:
         condition: service_started
 
   mgmt_backend_worker:
+    pull_policy: always
     container_name: ${MGMT_BACKEND_HOST}-worker
     image: ${MGMT_BACKEND_IMAGE}:${MGMT_BACKEND_VERSION}
     restart: unless-stopped
@@ -386,6 +395,7 @@ services:
         condition: service_healthy
 
   console:
+    pull_policy: always
     container_name: ${CONSOLE_HOST}
     image: ${CONSOLE_IMAGE}:${CONSOLE_VERSION}
     restart: unless-stopped


### PR DESCRIPTION
Because

- images especially `latest` tag ones should be always re-pulled to avoid stale context.

This commit

- add `pull_policy: always` in each compose service.
