### PR TITLE
chore(helm): update outdated Temporal config

### DIFF
--- a/charts/core/templates/mgmt-backend/configmap.yaml
+++ b/charts/core/templates/mgmt-backend/configmap.yaml
@@ -78,7 +78,7 @@ data:
     temporal:
       hostport: {{ default (printf "%s-frontend-headless:%s" (include "core.temporal" .) (include "core.temporal.frontend.grpcPort" .)) .Values.mgmtBackend.temporal.hostPort }}
       namespace: {{ default "mgmt-backend" .Values.mgmtBackend.temporal.namespace }}
-      ca: {{ default "" .Values.mgmtBackend.temporal.ca }}
-      cert: {{ default "" .Values.mgmtBackend.temporal.cert }}
-      key: {{ default "" .Values.mgmtBackend.temporal.key }}
+      serverrootca: {{ default "" .Values.mgmtBackend.temporal.serverRootCA }}
+      clientcert: {{ default "" .Values.mgmtBackend.temporal.clientCert }}
+      clientkey: {{ default "" .Values.mgmtBackend.temporal.clientKey }}
       serverName: {{ default "" .Values.mgmtBackend.temporal.serverName }}

--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -86,9 +86,9 @@ data:
       hostport: {{ default (printf "%s-frontend-headless:%s" (include "core.temporal" .) (include "core.temporal.frontend.grpcPort" .)) .Values.modelBackend.temporal.hostPort }}
       namespace: {{ default "model-backend" .Values.modelBackend.temporal.namespace }}
       retention: {{ default "1d" .Values.modelBackend.temporal.retention }}
-      ca: {{ default "" .Values.modelBackend.temporal.ca }}
-      cert: {{ default "" .Values.modelBackend.temporal.cert }}
-      key: {{ default "" .Values.modelBackend.temporal.key }}
+      serverrootca: {{ default "" .Values.modelBackend.temporal.serverRootCA }}
+      clientcert: {{ default "" .Values.modelBackend.temporal.clientCert }}
+      clientkey: {{ default "" .Values.modelBackend.temporal.clientKey }}
       serverName: {{ default "" .Values.modelBackend.temporal.serverName }}
     initmodel:
       {{- toYaml .Values.modelBackend.initModel | nindent 6 }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -390,9 +390,9 @@ mgmtBackend:
   temporal:
     hostPort:
     namespace:
-    ca:
-    cert:
-    key:
+    serverRootCA:
+    clientCert:
+    clientKey:
     serverName:
 # -- The configuration of pipeline-backend
 pipelineBackend:
@@ -562,9 +562,9 @@ modelBackend:
     hostPort:
     namespace:
     retention:
-    ca:
-    cert:
-    key:
+    serverRootCA:
+    clientCert:
+    clientKey:
     serverName:
     workflow:
       maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- we updated the Temporal config format in model and mgmt-backend.

This commit

- updates the outdated Temporal config in Helm Chart