### PR TITLE
ci(model): fix model integration test

### DIFF
--- a/.env
+++ b/.env
@@ -25,7 +25,7 @@ OBSERVE_ENABLED=false
 INITMODEL_ENABLED=false
 
 # Model inventory JSON file path to initialize model-backend with pre-deploy models
-INITMODEL_PATH=
+INITMODEL_INVENTORY=
 
 # Instill Core instance host. Set it with a valid network address (IP or URL) for the console.
 INSTILL_CORE_HOST=localhost

--- a/Makefile.helper
+++ b/Makefile.helper
@@ -211,7 +211,7 @@ endef
 define MODEL_INTEGRATION_TEST
 	@EDITION=docker-ce:test docker compose up registry -d
 	@$(MAKE) build-and-push-models
-	@$(MAKE) $(1) EDITION=docker-ce:test INITMODEL_ENABLED=true INITMODEL_PATH=${PWD}/integration-test/models/inventory.json
+	@$(MAKE) $(1) EDITION=docker-ce:test INITMODEL_ENABLED=true INITMODEL_INVENTORY=${PWD}/integration-test/models/inventory.json
 	@$(MAKE) wait-models-deploy
 	@$(MAKE) down
 endef

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -297,12 +297,11 @@ services:
     image: ${MODEL_BACKEND_IMAGE}:${MODEL_BACKEND_VERSION}
     restart: on-failure
     environment:
-      MODEL_BACKEND_HOST: ${MODEL_BACKEND_HOST}
       CFG_INITMODEL_ENABLED: ${INITMODEL_ENABLED}
-      CFG_INITMODEL_PATH: ${INITMODEL_PATH}
+      CFG_INITMODEL_INVENTORY: ${INITMODEL_INVENTORY}
     entrypoint: ./model-backend-init-model
     volumes:
-      - ${INITMODEL_PATH:-/dev/null}:${INITMODEL_PATH:-/dev/null}
+      - ${INITMODEL_INVENTORY:-/dev/null}:${INITMODEL_INVENTORY:-/dev/null}
     depends_on:
       model_backend:
         condition: service_healthy


### PR DESCRIPTION
Because

- model integration test was broken due to wrong init configuration. It's now fixed and I'd like to improve the overall config naming between model-backend and instill-core.

This commit

- update the initmodel config.
