### PR TITLE
ci(compose): remove profile selection

### DIFF
--- a/.env
+++ b/.env
@@ -9,9 +9,6 @@ COMPOSE_VOLUME_ELASTICSEARCH_DATA=elasticsearch-data
 COMPOSE_VOLUME_MINIO_DATA=minio-data
 COMPOSE_VOLUME_TEMPO_DATA=tempo-data
 
-# Docker Compose profiles to selectively launch components for development
-PROFILE=api-gateway,mgmt,pipeline,model,artifact,console
-
 # System-wise config path
 SYSTEM_CONFIG_PATH=~/.config/instill
 

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,9 @@ endif
 latest:			## Lunch all dependent services with their latest codebase
 	$(call ensure_user_uid)
 ifeq (${NVIDIA_GPU_AVAILABLE}, true)
-	$(call COMPOSE_GPU,$(call GET_COMPOSE_PARAMS,latest) COMPOSE_PROFILES=${PROFILE},${COMPOSE_FILES} -f docker-compose-latest.yml)
+	$(call COMPOSE_GPU,$(call GET_COMPOSE_PARAMS,latest),${COMPOSE_FILES} -f docker-compose-latest.yml)
 else
-	$(call COMPOSE_CPU,$(call GET_COMPOSE_PARAMS,latest) COMPOSE_PROFILES=${PROFILE},${COMPOSE_FILES} -f docker-compose-latest.yml)
+	$(call COMPOSE_CPU,$(call GET_COMPOSE_PARAMS,latest),${COMPOSE_FILES} -f docker-compose-latest.yml)
 endif
 
 .PHONY: helm-latest

--- a/docker-compose-latest.yml
+++ b/docker-compose-latest.yml
@@ -1,7 +1,5 @@
 services:
   api_gateway:
-    profiles:
-      - api-gateway
     image: ${API_GATEWAY_IMAGE}:latest
     environment:
       LOG_LEVEL: DEBUG
@@ -11,8 +9,6 @@ services:
       - ${API_GATEWAY_METRICS_HOST_PORT}:${API_GATEWAY_METRICS_PORT}
 
   pipeline_backend:
-    profiles:
-      - pipeline
     image: ${PIPELINE_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -22,16 +18,12 @@ services:
       - ${PIPELINE_BACKEND_HOST_PUBLICPORT}:${PIPELINE_BACKEND_PUBLICPORT}
 
   pipeline_backend_worker:
-    profiles:
-      - pipeline
     image: ${PIPELINE_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
       CFG_SERVER_EDITION: ${EDITION}
 
   artifact_backend:
-    profiles:
-      - artifact
     image: ${ARTIFACT_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -41,8 +33,6 @@ services:
       - ${ARTIFACT_BACKEND_HOST_PUBLICPORT}:${ARTIFACT_BACKEND_PUBLICPORT}
 
   model_backend:
-    profiles:
-      - model
     image: ${MODEL_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -52,20 +42,14 @@ services:
       - ${MODEL_BACKEND_HOST_PUBLICPORT}:${MODEL_BACKEND_PUBLICPORT}
 
   model_backend_init_model:
-    profiles:
-      - model
     image: ${MODEL_BACKEND_IMAGE}:latest
 
   model_backend_worker:
-    profiles:
-      - model
     image: ${MODEL_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
 
   mgmt_backend:
-    profiles:
-      - mgmt
     image: ${MGMT_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -75,16 +59,12 @@ services:
       - ${MGMT_BACKEND_HOST_PUBLICPORT}:${MGMT_BACKEND_PUBLICPORT}
 
   mgmt_backend_worker:
-    profiles:
-      - mgmt
     image: ${MGMT_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
       CFG_SERVER_EDITION: ${EDITION}
 
   console:
-    profiles:
-      - console
     image: ${CONSOLE_IMAGE}:latest
     environment:
       NEXT_PUBLIC_USAGE_COLLECTION_ENABLED: ${USAGE_ENABLED}


### PR DESCRIPTION
Because
- The Docker Compose profile setting is no longer suitable due to increasing backend service complexity.
- Some services, like artifact-backend, now depend on multiple other services (mgmt-backend and pipeline-backend), making the previous profiles logic (exclusive/inclusive) unworkable.
- Maintaining profiles for this growing dependency graph has become confusing and error-prone for local development.

This commit
- Removes the profile setting from the Docker Compose configuration.
- Simplifies local development by requiring developers to run only the necessary containers manually.
- Removes guidance or logic related to docker run or container orchestration via profiles.