### PR TITLE
ci(compose): fix dependency order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,13 +109,7 @@ services:
       retries: 60
       start_period: 15s
     depends_on:
-      temporal:
-        condition: service_healthy
-      pg_sql:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      openfga:
+      pipeline_backend_worker:
         condition: service_started
 
   pipeline_backend_worker:
@@ -152,8 +146,14 @@ services:
       CFG_INFLUXDB_URL: http://${INFLUXDB_HOST}:${INFLUXDB_PORT}
     entrypoint: ./pipeline-backend-worker
     depends_on:
-      pipeline_backend:
+      temporal:
         condition: service_healthy
+      pg_sql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      openfga:
+        condition: service_started
 
   artifact_backend:
     pull_policy: missing
@@ -254,18 +254,8 @@ services:
       retries: 60
       start_period: 15s
     depends_on:
-      ray:
-        condition: service_healthy
-      temporal:
-        condition: service_healthy
-      pg_sql:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      openfga:
+      model_backend_worker:
         condition: service_started
-      artifact_backend:
-        condition: service_healthy
 
   model_backend_worker:
     pull_policy: missing
@@ -286,7 +276,17 @@ services:
       CFG_INFLUXDB_URL: http://${INFLUXDB_HOST}:${INFLUXDB_PORT}
     entrypoint: ./model-backend-worker
     depends_on:
-      model_backend:
+      ray:
+        condition: service_healthy
+      temporal:
+        condition: service_healthy
+      pg_sql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      openfga:
+        condition: service_started
+      artifact_backend:
         condition: service_healthy
 
   model_backend_init_model:
@@ -341,15 +341,9 @@ services:
       interval: 5s
       timeout: 3s
       retries: 60
-      start_period: 10s
+      start_period: 20s
     depends_on:
-      pg_sql:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      temporal:
-        condition: service_healthy
-      openfga:
+      mgmt_backend_worker:
         condition: service_started
 
   mgmt_backend_worker:
@@ -373,8 +367,14 @@ services:
       CFG_INFLUXDB_URL: http://${INFLUXDB_HOST}:${INFLUXDB_PORT}
     entrypoint: ./mgmt-backend-worker
     depends_on:
-      mgmt_backend:
+      pg_sql:
         condition: service_healthy
+      redis:
+        condition: service_healthy
+      temporal:
+        condition: service_healthy
+      openfga:
+        condition: service_started
 
   console:
     pull_policy: missing
@@ -465,7 +465,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 60
-      start_period: 60s
+      start_period: 20s
 
   pg_sql:
     container_name: ${POSTGRESQL_HOST}


### PR DESCRIPTION
Because

- service main binary depends on worker binary for the Temporal namespace.

This commit

- fixes the dependency order.
