### PR TITLE
ci(makefile): simplify deployment by using git hash for service version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -126,16 +126,6 @@ Simply run:
 make down
 ```
 
-### Build the local images
-
-We use Docker multi-stage builds to create `instill/instill-core:{latest,release}` images, which utilize Docker-in-Docker (dind) to build all the images of **🔮 Instill Core** defined in the [docker-compose-build.yml](../docker-compose-build.yml) compose file.
-
-You can build all the service images by running:
-
-```shell
-make build-{latest,release} BUILD_ALL_FROM_SOURCE=true
-```
-
 ## Configurations
 
 ### Backend Services

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,31 +20,31 @@ Please refer to [prerequisites section](../README.md#prerequisites) to make sure
 
 **Instill Core CE** is built with the [microservice architecture](/docs/faq#tech). We use Docker Compose for local development. Each service is nothing but a running container. Developing new features simply means to develop, containerize and deploy the new codebase.
 
-Clone the repo and launch the `latest` version of the codebase for all dependencies:
+Clone the repo and launch the system with development profile:
 
 ```shell
 # Clone and move to the instill-core repository
 git clone https://github.com/instill-ai/instill-core.git
 cd instill-core
 
-# Launch all services with their very latest versions
-make latest
+# Launch all services with development profile
+make compose-dev
 ```
 
 Once every containers are up and running, the developer can access all services through:
 
-* [`api-gateway`](https://github.com/instill-ai/api-gateway/blob/main/config/config.yaml) (`localhost:8080`)
-  * A service to handle API requests and responses.
-* [`pipeline-backend`](https://github.com/instill-ai/pipeline-backend/blob/main/config/config.yaml)(`localhost:8081`)
-  * A service for building and managing unstructured data pipelines.
-* [`artifact-backend`](https://github.com/instill-ai/artifact-backend/blob/main/config/config.yaml)(`localhost:8082`)
-  * A service for managing all RAG related resources.
-* [`model-backend`](https://github.com/instill-ai/model-backend/blob/main/config/config.yaml)(`localhost:8083`)
-  * A service for importing and serving AI models.
-* [`mgmt-backend`](https://github.com/instill-ai/mgmt-backend/blob/main/config/config.yaml)(`localhost:8084`)
-  * A service for user account management, including authentication, authorization, admission control and usage metrics.
-* [`console`](https://github.com/instill-ai/console/blob/main/.env) (`localhost:3000`)
-  * A service provides GUI user interface for accessing **Instill Core CE**.
+- [`api-gateway`](https://github.com/instill-ai/api-gateway/blob/main/config/config.yaml) (`localhost:8080`)
+  - A service to handle API requests and responses.
+- [`pipeline-backend`](https://github.com/instill-ai/pipeline-backend/blob/main/config/config.yaml)(`localhost:8081`)
+  - A service for building and managing unstructured data pipelines.
+- [`artifact-backend`](https://github.com/instill-ai/artifact-backend/blob/main/config/config.yaml)(`localhost:8082`)
+  - A service for managing all RAG related resources.
+- [`model-backend`](https://github.com/instill-ai/model-backend/blob/main/config/config.yaml)(`localhost:8083`)
+  - A service for importing and serving AI models.
+- [`mgmt-backend`](https://github.com/instill-ai/mgmt-backend/blob/main/config/config.yaml)(`localhost:8084`)
+  - A service for user account management, including authentication, authorization, admission control and usage metrics.
+- [`console`](https://github.com/instill-ai/console/blob/main/.env) (`localhost:3000`)
+  - A service provides GUI user interface for accessing **Instill Core CE**.
 
 ### Component environment variables
 
@@ -139,7 +139,6 @@ Besides, **Instill Core CE** uses [Koanf](https://github.com/knadh/koanf) librar
 To access Instill Core Console, set the host by overriding the environment variables:
 
 ```shellscript .env
-<code_block_to_apply_changes_from>
 INSTILL_CORE_HOST={HOSTNAME}
 ```
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -82,8 +82,7 @@ cd pipeline-backend
 #### Build and run the dev image
 
 ```shell
-make build-dev
-make dev
+make compose-dev
 ```
 
 Now, you have the development environment set up in the container, where you can compile and run the binaries, as well as run the integration tests in the container.

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,26 +7,8 @@ on:
       - "**"
 
 jobs:
-  determine-target:
-    runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      !startsWith(github.ref, 'refs/heads/release-please--branches') ||
-      (startsWith(github.ref, 'refs/heads/release-please--branches') && contains(github.event.head_commit.message, 'chore(main): release'))
-    outputs:
-      target: ${{ steps.set-target.outputs.target }}
-    steps:
-      - name: Set target based on branch
-        id: set-target
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/release-please--branches--main" ]]; then
-            echo "target=release" >> $GITHUB_OUTPUT
-          else
-            echo "target=latest" >> $GITHUB_OUTPUT
-          fi
 
   compose:
-    needs: determine-target
     runs-on: ubuntu-latest
     steps:
       - name: Maximize build space
@@ -55,28 +37,18 @@ jobs:
         with:
           envFile: .env
 
-      - name: Launch Instill Core Docker Compose integration test (${{ needs.determine-target.outputs.target }})
+      - name: Launch Instill Core Docker Compose integration test
         # CFG_COMPONENT_SECRETS_GITHUB* variables are injected to test OAuth
         # connection creation on `pipeline-backend`.
         run: |
-          if [ "${{ needs.determine-target.outputs.target }}" == "latest" ]; then
-            make build-latest
-            make compose-integration-test-latest
-          elif [ "${{ needs.determine-target.outputs.target }}" == "release" ]  ; then
-            make build-release
-            make compose-integration-test-release
-          else
-            echo "Invalid target: ${{ needs.determine-target.outputs.target }}"
-            exit 1
-          fi
+          make compose-integration-test
 
-      - name: Tear down Instill Core (${{ needs.determine-target.outputs.target }})
+      - name: Tear down Instill Core
         if: always()
         run: |
           make down
 
   helm:
-    needs: determine-target
     runs-on: ubuntu-latest
     steps:
       - name: Maximize build space
@@ -109,20 +81,11 @@ jobs:
         with:
           envFile: .env
 
-      - name: Launch Instill Core Helm integration test(${{ needs.determine-target.outputs.target }})
+      - name: Launch Instill Core Helm integration test
         # CFG_COMPONENT_SECRETS_GITHUB* variables are injected to test OAuth
         # connection creation on `pipeline-backend`.
         run: |
-          if [ "${{ needs.determine-target.outputs.target }}" == "latest" ]; then
-            make build-latest
-            make helm-integration-test-latest
-          elif [ "${{ needs.determine-target.outputs.target }}" == "release" ]  ; then
-            make build-release
-            make helm-integration-test-release
-          else
-            echo "Invalid target: ${{ needs.determine-target.outputs.target }}"
-            exit 1
-          fi
+          make helm-integration-test
 
       - name: Tear down Instill Core (${{ needs.determine-target.outputs.target }})
         if: always()
@@ -130,7 +93,6 @@ jobs:
           make down
 
   model:
-    needs: determine-target
     runs-on: ubuntu-latest
     steps:
       - name: Maximize build space
@@ -176,12 +138,12 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Run model integration test (${{ needs.determine-target.outputs.target }})
+      - name: Run model integration test
         working-directory: instill-core
         run: |
-          make model-integration-test-${{ needs.determine-target.outputs.target }}
+          make model-integration-test
 
-      - name: Tear down Instill Core (${{ needs.determine-target.outputs.target }})
+      - name: Tear down Instill Core
         if: always()
         working-directory: instill-core
         run: |

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -8,22 +8,7 @@ on:
       - main
 
 jobs:
-  determine-target:
-    runs-on: ubuntu-latest
-    outputs:
-      target: ${{ steps.set-target.outputs.target }}
-    steps:
-      - name: Set target based on branch
-        id: set-target
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/release-please--branches--main" ]]; then
-            echo "target=all" >> $GITHUB_OUTPUT
-          else
-            echo "target=latest" >> $GITHUB_OUTPUT
-          fi
-
   make:
-    needs: determine-target
     runs-on: ubuntu-latest
     steps:
       - name: Maximize build space
@@ -50,21 +35,14 @@ jobs:
         with:
           envFile: .env
 
-      - name: Launch Instill Core (${{ needs.determine-target.outputs.target }})
+      - name: Launch Instill Core
         run: |
-          if [ "${{ needs.determine-target.outputs.target }}" == "latest" ]; then
-            make latest EDITION=docker-ce:test
-          elif [ "${{ needs.determine-target.outputs.target }}" == "all" ]; then
-            make all EDITION=docker-ce:test
-          else
-            echo "Invalid target: ${{ needs.determine-target.outputs.target }}"
-            exit 1
-          fi
+          make compose-run EDITION=docker-ce:test
 
       - name: List all docker containers
         run: |
           docker ps -a
-          sleep ${{ needs.determine-target.outputs.target == 'all' && '60' || '30' }}
+          sleep 60
 
       - name: Probe to Instill Core services healthcheck endpoint
         run: |
@@ -73,7 +51,7 @@ jobs:
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/v1beta/health/model
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/v1beta/health/artifact
 
-      - name: Tear down Instill Core (${{ needs.determine-target.outputs.target }})
+      - name: Tear down Instill Core
         if: always()
         run: |
           make down

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG GOLANG_VERSION=1.24.4
 ARG ALPINE_VERSION=3.21
 FROM golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} AS base
 
-RUN apk add --update docker docker-compose docker-cli-compose docker-cli-buildx openrc containerd git bash make wget vim curl openssl util-linux
+RUN apk add --update git bash make wget vim curl
 
 ARG K6_VERSION XK6_VERSION XK6_SQL_VERSION XK6_SQL_POSTGRES_VERSION
 RUN go install go.k6.io/xk6/cmd/xk6@v${XK6_VERSION}
@@ -11,65 +11,11 @@ RUN xk6 build v${K6_VERSION} \
   --with github.com/grafana/xk6-sql-driver-postgres@v${XK6_SQL_POSTGRES_VERSION} \
   --output /usr/bin/k6
 
-# Install Helm
-RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-
-# Install Kubectl
-ARG TARGETARCH
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl
-RUN chmod +x ./kubectl
-RUN mv ./kubectl /usr/local/bin
-
-FROM alpine:${ALPINE_VERSION} AS latest
-
-COPY --from=base /etc /etc
-COPY --from=base /usr /usr
-COPY --from=base /lib /lib
-COPY --from=docker:dind /usr/local/bin /usr/local/bin
-
-ARG CACHE_DATE
-RUN echo "Instill Core latest codebase cloned on ${CACHE_DATE}"
-
-WORKDIR /instill-core
-
-ARG API_GATEWAY_COMMIT_SHORT_SHA
-ARG PIPELINE_BACKEND_COMMIT_SHORT_SHA
-ARG ARTIFACT_BACKEND_COMMIT_SHORT_SHA
-ARG MODEL_BACKEND_COMMIT_SHORT_SHA
-ARG MGMT_BACKEND_COMMIT_SHORT_SHA
-ARG CONSOLE_COMMIT_SHORT_SHA
-
-RUN git clone --depth=1 https://github.com/instill-ai/api-gateway.git
-RUN cd api-gateway && git config advice.detachedHead false && git fetch origin && git checkout ${API_GATEWAY_COMMIT_SHORT_SHA}
-
-RUN git clone --depth=1 https://github.com/instill-ai/pipeline-backend.git
-RUN cd pipeline-backend && git config advice.detachedHead false && git fetch origin && git checkout ${PIPELINE_BACKEND_COMMIT_SHORT_SHA}
-
-RUN git clone --depth=1 https://github.com/instill-ai/artifact-backend.git
-RUN cd artifact-backend && git config advice.detachedHead false && git fetch origin && git checkout ${ARTIFACT_BACKEND_COMMIT_SHORT_SHA}
-
-RUN git clone --depth=1 https://github.com/instill-ai/model-backend.git
-RUN cd model-backend && git config advice.detachedHead false && git fetch origin && git checkout ${MODEL_BACKEND_COMMIT_SHORT_SHA}
-
-RUN git clone --depth=1 https://github.com/instill-ai/mgmt-backend.git
-RUN cd mgmt-backend && git config advice.detachedHead false && git fetch origin && git checkout ${MGMT_BACKEND_COMMIT_SHORT_SHA}
-
-RUN git clone --depth=1 https://github.com/instill-ai/console.git
-RUN cd console && git config advice.detachedHead false && git fetch origin && git checkout ${CONSOLE_COMMIT_SHORT_SHA}
-
-ENV API_GATEWAY_VERSION=${API_GATEWAY_COMMIT_SHORT_SHA}
-ENV PIPELINE_BACKEND_VERSION=${PIPELINE_BACKEND_COMMIT_SHORT_SHA}
-ENV ARTIFACT_BACKEND_VERSION=${ARTIFACT_BACKEND_COMMIT_SHORT_SHA}
-ENV MODEL_BACKEND_VERSION=${MODEL_BACKEND_COMMIT_SHORT_SHA}
-ENV MGMT_BACKEND_VERSION=${MGMT_BACKEND_COMMIT_SHORT_SHA}
-ENV CONSOLE_VERSION=${CONSOLE_COMMIT_SHORT_SHA}
-
 FROM alpine:${ALPINE_VERSION} AS release
 
 COPY --from=base /etc /etc
 COPY --from=base /usr /usr
 COPY --from=base /lib /lib
-COPY --from=docker:dind /usr/local/bin /usr/local/bin
 
 ARG CACHE_DATE
 RUN echo "Instill Core release codebase cloned on ${CACHE_DATE}"
@@ -83,12 +29,52 @@ ARG MODEL_BACKEND_VERSION
 ARG MGMT_BACKEND_VERSION
 ARG CONSOLE_VERSION
 
-RUN git clone --depth=1 -b v${API_GATEWAY_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/api-gateway.git
-RUN git clone --depth=1 -b v${PIPELINE_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/pipeline-backend.git
-RUN git clone --depth=1 -b v${ARTIFACT_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/artifact-backend.git
-RUN git clone --depth=1 -b v${MODEL_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/model-backend.git
-RUN git clone --depth=1 -b v${MGMT_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/mgmt-backend.git
-RUN git clone --depth=1 -b v${CONSOLE_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/console.git
+ENV SEMATIC_VERSION_REGEX="^[0-9]+\.[0-9]+\.[0-9]+"
+
+RUN if echo "${API_GATEWAY_VERSION}" | grep -qE ${SEMATIC_VERSION_REGEX}; then \
+        git clone --depth=1 -b v${API_GATEWAY_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/api-gateway.git; \
+    else \
+        # TODO: we should implement a better way to shallow clone the repo
+        git clone https://github.com/instill-ai/api-gateway.git; \
+        cd api-gateway; \
+        git checkout ${API_GATEWAY_VERSION}; \
+    fi
+
+RUN if echo "${PIPELINE_BACKEND_VERSION}" | grep -qE ${SEMATIC_VERSION_REGEX}; then \
+        git clone --depth=1 -b v${PIPELINE_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/pipeline-backend.git; \
+    else \
+        # TODO: we should implement a better way to shallow clone the repo
+        git clone https://github.com/instill-ai/pipeline-backend.git; \
+        cd pipeline-backend; \
+        git checkout ${PIPELINE_BACKEND_VERSION}; \
+    fi
+
+RUN if echo "${ARTIFACT_BACKEND_VERSION}" | grep -qE ${SEMATIC_VERSION_REGEX}; then \
+        git clone --depth=1 -b v${ARTIFACT_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/artifact-backend.git; \
+    else \
+        # TODO: we should implement a better way to shallow clone the repo
+        git clone https://github.com/instill-ai/artifact-backend.git; \
+        cd artifact-backend; \
+        git checkout ${ARTIFACT_BACKEND_VERSION}; \
+    fi
+
+RUN if echo "${MODEL_BACKEND_VERSION}" | grep -qE ${SEMATIC_VERSION_REGEX}; then \
+        git clone --depth=1 -b v${MODEL_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/model-backend.git; \
+    else \
+        # TODO: we should implement a better way to shallow clone the repo
+        git clone https://github.com/instill-ai/model-backend.git; \
+        cd model-backend; \
+        git checkout ${MODEL_BACKEND_VERSION}; \
+    fi
+
+RUN if echo "${MGMT_BACKEND_VERSION}" | grep -qE ${SEMATIC_VERSION_REGEX}; then \
+        git clone --depth=1 -b v${MGMT_BACKEND_VERSION} -c advice.detachedHead=false https://github.com/instill-ai/mgmt-backend.git; \
+    else \
+        # TODO: we should implement a better way to shallow clone the repo
+        git clone https://github.com/instill-ai/mgmt-backend.git; \
+        cd mgmt-backend; \
+        git checkout ${MGMT_BACKEND_VERSION}; \
+    fi
 
 ENV API_GATEWAY_VERSION=${API_GATEWAY_VERSION}
 ENV PIPELINE_BACKEND_VERSION=${PIPELINE_BACKEND_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ top:			## Display all running service processes
 
 .PHONY: integration-test
 integration-test:                   ## Run all integration tests (compose, helm, and model)
-	$(call BUILD_TEST)
+	$(call BUILD_DEV)
 	$(call MODEL_INTEGRATION_TEST)
 	$(call COMPOSE_INTEGRATION_TEST)
 	$(call HELM_INTEGRATION_TEST)

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,9 @@ ifeq ($(shell nvidia-smi 2>/dev/null 1>&2; echo $$?),0)
 	ifndef NVIDIA_VISIBLE_DEVICES
 		NVIDIA_VISIBLE_DEVICES := all
 	endif
-	RAY_LATEST_TAG := latest-gpu
 	RAY_RELEASE_TAG := ${RAY_VERSION}-gpu
 else
 	NVIDIA_GPU_AVAILABLE := false
-	RAY_LATEST_TAG := latest
 	RAY_RELEASE_TAG := ${RAY_VERSION}
 endif
 
@@ -36,7 +34,6 @@ UNAME_S := $(shell uname -s)
 
 INSTILL_CORE_IMAGE_NAME := instill/instill-core
 
-CONTAINER_BUILD_NAME := instill-core-build
 CONTAINER_COMPOSE_INTEGRATION_TEST_NAME := instill-core-compose-integration-test
 
 HELM_NAMESPACE := instill-ai
@@ -50,43 +47,37 @@ ENV_SECRETS_CONSOLE := .env.secrets.console
 # Configuration directory path
 CONFIG_DIR_PATH := ./configs
 
+GIT_COMMIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null)
+
 #============================================================================
 
 include Makefile.helper
 
-.PHONY: all
-all:			## Launch all services with their up-to-date release version
+.PHONY: run
+run: compose-run	## Alias for compose-run: Launch all services by docker compose
+
+
+.PHONY: compose-run
+compose-run:	## Launch all services by docker compose
 	$(call ensure_user_uid)
 ifeq (${NVIDIA_GPU_AVAILABLE}, true)
-	$(call COMPOSE_GPU,$(call GET_COMPOSE_PARAMS,release),${COMPOSE_FILES})
+	$(call COMPOSE_GPU,$(call GET_COMPOSE_PARAMS),${COMPOSE_FILES})
 else
-	$(call COMPOSE_CPU,$(call GET_COMPOSE_PARAMS,release),${COMPOSE_FILES})
+	$(call COMPOSE_CPU,$(call GET_COMPOSE_PARAMS),${COMPOSE_FILES})
 endif
 
-.PHONY: latest
-latest:			## Lunch all dependent services with their latest codebase
+.PHONY: compose-dev
+compose-dev:	## Lunch all services with docker compose dev profile
 	$(call ensure_user_uid)
 ifeq (${NVIDIA_GPU_AVAILABLE}, true)
-	$(call COMPOSE_GPU,$(call GET_COMPOSE_PARAMS,latest),${COMPOSE_FILES} -f docker-compose-latest.yml)
+	$(call COMPOSE_GPU,$(call GET_COMPOSE_PARAMS) COMPOSE_PROFILES=${COMPOSE_FILES} -f docker-compose-dev.yml)
 else
-	$(call COMPOSE_CPU,$(call GET_COMPOSE_PARAMS,latest),${COMPOSE_FILES} -f docker-compose-latest.yml)
+	$(call COMPOSE_CPU,$(call GET_COMPOSE_PARAMS) COMPOSE_PROFILES=${COMPOSE_FILES} -f docker-compose-dev.yml)
 endif
 
-.PHONY: helm-latest
-helm-latest:
-	$(call HELM,latest,$(CI))
-
-.PHONY: helm-release
-helm-release:
-	$(call HELM,release,$(CI))
-
-.PHONY: build-latest
-build-latest:				## Build latest image. Set BUILD_ALL_FROM_SOURCE=true to build all service images from source.
-	$(call BUILD,latest)
-
-.PHONY: build-release
-build-release:				## Build release image. Set BUILD_ALL_FROM_SOURCE=true to build all service images from source.
-	$(call BUILD,release)
+.PHONY: helm-run
+helm-run:		## Launch all services by helm
+	$(call HELM,$(CI))
 
 .PHONY: down
 down:			## Stop all services and remove all service containers and volumes
@@ -125,29 +116,28 @@ ps:				## List all service containers
 top:			## Display all running service processes
 	@EDITION= DEFAULT_USER_UID= docker compose top
 
-.PHONY: model-integration-test-latest
-model-integration-test-latest:       	 	# Run integration test on the latest Instill Core to build, push and deploy dummy models
-	$(call MODEL_INTEGRATION_TEST,latest)
+.PHONY: integration-test
+integration-test:                   ## Run all integration tests (compose, helm, and model)
+	$(call BUILD_TEST)
+	$(call MODEL_INTEGRATION_TEST)
+	$(call COMPOSE_INTEGRATION_TEST)
+	$(call HELM_INTEGRATION_TEST)
 
-.PHONY: model-integration-test-release
-model-integration-test-release:       	 	# Run integration test on the released Instill Core to build, push and deploy dummy models
-	$(call MODEL_INTEGRATION_TEST,all)
 
-.PHONY: compose-integration-test-latest
-compose-integration-test-latest:			# Run integration test on the latest Instill Core Docker Compose
-	$(call COMPOSE_INTEGRATION_TEST,latest,latest)
+.PHONY: model-integration-test
+model-integration-test:       	 	# Run integration test on the Instill Core to build, push and deploy dummy models
+	$(call BUILD_TEST)
+	$(call MODEL_INTEGRATION_TEST)
 
-.PHONY: compose-integration-test-release
-compose-integration-test-release:			# Run integration test on the released Instill Core Docker Compose
-	$(call COMPOSE_INTEGRATION_TEST,all,release)
+.PHONY: compose-integration-test
+compose-integration-test:			# Run integration test on the Instill Core Docker Compose
+	$(call BUILD_TEST)
+	$(call COMPOSE_INTEGRATION_TEST)
 
-.PHONY: helm-integration-test-latest
-helm-integration-test-latest:                       # Run integration test on the latest Instill Core Helm
-	$(call HELM_INTEGRATION_TEST,latest)
-
-.PHONY: helm-integration-test-release
-helm-integration-test-release:                       # Run integration test on the released Instill Core Helm
-	$(call HELM_INTEGRATION_TEST,release)
+.PHONY: helm-integration-test
+helm-integration-test:              # Run integration test on the Instill Core Helm
+	$(call BUILD_TEST)
+	$(call HELM_INTEGRATION_TEST)
 
 .PHONY: build-and-push-models
 build-and-push-models:	# Helper target to build and push models

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ run: compose-run	## Alias for compose-run: Launch all services by docker compose
 
 .PHONY: compose-run
 compose-run:	## Launch all services by docker compose
-	$(call ensure_user_uid)
+	$(call ENSURE_USER_UID)
 ifeq (${NVIDIA_GPU_AVAILABLE}, true)
 	$(call COMPOSE_GPU,$(call GET_COMPOSE_PARAMS),${COMPOSE_FILES})
 else
@@ -68,7 +68,7 @@ endif
 
 .PHONY: compose-dev
 compose-dev:	## Lunch all services with docker compose dev profile
-	$(call ensure_user_uid)
+	$(call ENSURE_USER_UID)
 ifeq (${NVIDIA_GPU_AVAILABLE}, true)
 	$(call COMPOSE_GPU,$(call GET_COMPOSE_PARAMS) COMPOSE_PROFILES=${COMPOSE_FILES} -f docker-compose-dev.yml)
 else
@@ -161,4 +161,4 @@ wait-models-deploy:  # Helper target to wait for model deployment
 .PHONY: help
 help:       	## Show this help
 	@printf "\nMake Application with Instill Core\n"
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m (default: help)\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m (default: help)\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -126,17 +126,17 @@ integration-test:                   ## Run all integration tests (compose, helm,
 
 .PHONY: model-integration-test
 model-integration-test:       	 	# Run integration test on the Instill Core to build, push and deploy dummy models
-	$(call BUILD_TEST)
+	$(call BUILD_DEV)
 	$(call MODEL_INTEGRATION_TEST)
 
 .PHONY: compose-integration-test
 compose-integration-test:			# Run integration test on the Instill Core Docker Compose
-	$(call BUILD_TEST)
+	$(call BUILD_DEV)
 	$(call COMPOSE_INTEGRATION_TEST)
 
 .PHONY: helm-integration-test
 helm-integration-test:              # Run integration test on the Instill Core Helm
-	$(call BUILD_TEST)
+	$(call BUILD_DEV)
 	$(call HELM_INTEGRATION_TEST)
 
 .PHONY: build-and-push-models

--- a/Makefile.helper
+++ b/Makefile.helper
@@ -12,8 +12,7 @@ endef
 define GET_COMPOSE_PARAMS
 	$(if $(filter true,$(CI)),EDITION=docker-ce:test,EDITION=$${EDITION:=local-ce}) \
 	DEFAULT_USER_UID=$$(cat ${SYSTEM_CONFIG_PATH}/user_uid) \
-	$(if $(filter true,$(CI)),ENV_SECRETS_COMPONENT=${ENV_SECRETS_COMPONENT_TEST},ENV_SECRETS_COMPONENT=${ENV_SECRETS_COMPONENT}) \
-	$(if $(filter latest,$(1)),RAY_LATEST_TAG=${RAY_LATEST_TAG},RAY_RELEASE_TAG=${RAY_RELEASE_TAG})
+	$(if $(filter true,$(CI)),ENV_SECRETS_COMPONENT=${ENV_SECRETS_COMPONENT_TEST},ENV_SECRETS_COMPONENT=${ENV_SECRETS_COMPONENT})
 endef
 
 # Function to launch docker compose with GPU support
@@ -32,116 +31,59 @@ define HELM
 	@cd charts/core && helm dependency update
 	@helm install ${HELM_RELEASE_NAME} charts/core \
 		--namespace ${HELM_NAMESPACE} --create-namespace \
-		--set edition=$(if $(filter true,$(2)),k8s-ce:test,$(if $(filter latest,$(1)),k8s-ce:latest,k8s-ce)) \
-		--set apiGateway.image.tag=$(if $(filter latest,$(1)),latest,${API_GATEWAY_VERSION}) \
-		--set mgmtBackend.image.tag=$(if $(filter latest,$(1)),latest,${MGMT_BACKEND_VERSION}) \
+		--set edition=$(if $(filter true,$(1)),k8s-ce:test,k8s-ce) \
+		--set apiGateway.image.tag=${API_GATEWAY_VERSION} \
+		--set mgmtBackend.image.tag=${MGMT_BACKEND_VERSION} \
 		--set mgmtBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-		--set artifactBackend.image.tag=$(if $(filter latest,$(1)),latest,${ARTIFACT_BACKEND_VERSION}) \
+		--set artifactBackend.image.tag=${ARTIFACT_BACKEND_VERSION} \
 		--set artifactBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-		--set pipelineBackend.image.tag=$(if $(filter latest,$(1)),latest,${PIPELINE_BACKEND_VERSION}) \
+		--set pipelineBackend.image.tag=${PIPELINE_BACKEND_VERSION} \
 		--set pipelineBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
 		--set modelBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-		--set modelBackend.image.tag=$(if $(filter latest,$(1)),latest,${MODEL_BACKEND_VERSION}) \
-		--set console.image.tag=$(if $(filter latest,$(1)),latest,${CONSOLE_VERSION}) \
-		--set ray-cluster.image.tag=$(if $(filter latest,$(1)),${RAY_LATEST_TAG},${RAY_RELEASE_TAG}) \
-		$(if $(filter true,$(2)),--set ray-cluster.head.autoscaling.enableInTreeAutoscaling=false,) \
-		$(if $(filter true,$(2)),--set ray-cluster.head.resources.requests.cpu=0,) \
-		$(if $(filter true,$(2)),--set ray-cluster.head.resources.requests.memory=0,) \
-		$(if $(filter true,$(2)),--set ray-cluster.worker.resources.requests.cpu=0,) \
-		$(if $(filter true,$(2)),--set ray-cluster.worker.resources.requests.memory=0,) \
-		$(if $(filter true,$(2)),--set jaeger.enabled=false,) \
-		$(if $(filter true,$(2)),--set opentelemetry-collector.enabled=false,) \
-		$(if $(filter true,$(2)),--set kube-prometheus-stack.enabled=false,) \
-		$(if $(filter true,$(2)),--set 'pipelineBackend.extraEnv[0].name=CFG_COMPONENT_SECRETS_GITHUB_OAUTHCLIENTID',) \
-		$(if $(filter true,$(2)),--set 'pipelineBackend.extraEnv[0].value=foo',) \
-		$(if $(filter true,$(2)),--set 'pipelineBackend.extraEnv[1].name=CFG_COMPONENT_SECRETS_GITHUB_OAUTHCLIENTSECRET',) \
-		$(if $(filter true,$(2)),--set 'pipelineBackend.extraEnv[1].value=foo',) \
+		--set modelBackend.image.tag=${MODEL_BACKEND_VERSION} \
+		--set console.image.tag=${CONSOLE_VERSION} \
+		--set ray-cluster.image.tag=${RAY_RELEASE_TAG} \
+		$(if $(filter true,$(1)),--set ray-cluster.head.autoscaling.enableInTreeAutoscaling=false,) \
+		$(if $(filter true,$(1)),--set ray-cluster.head.resources.requests.cpu=0,) \
+		$(if $(filter true,$(1)),--set ray-cluster.head.resources.requests.memory=0,) \
+		$(if $(filter true,$(1)),--set ray-cluster.worker.resources.requests.cpu=0,) \
+		$(if $(filter true,$(1)),--set ray-cluster.worker.resources.requests.memory=0,) \
+		$(if $(filter true,$(1)),--set jaeger.enabled=false,) \
+		$(if $(filter true,$(1)),--set opentelemetry-collector.enabled=false,) \
+		$(if $(filter true,$(1)),--set kube-prometheus-stack.enabled=false,) \
+		$(if $(filter true,$(1)),--set 'pipelineBackend.extraEnv[0].name=CFG_COMPONENT_SECRETS_GITHUB_OAUTHCLIENTID',) \
+		$(if $(filter true,$(1)),--set 'pipelineBackend.extraEnv[0].value=foo',) \
+		$(if $(filter true,$(1)),--set 'pipelineBackend.extraEnv[1].name=CFG_COMPONENT_SECRETS_GITHUB_OAUTHCLIENTSECRET',) \
+		$(if $(filter true,$(1)),--set 'pipelineBackend.extraEnv[1].value=foo',) \
 		--timeout 30m0s
 endef
 
 # Function to build image
-define BUILD
+define BUILD_TEST
 	@bash -c ' \
 		set -e; \
 		trap "$(MAKE) down" ERR INT TERM && \
-		$(if $(filter latest,$(1)), \
-			API_GATEWAY_COMMIT_SHORT_SHA=$$(git ls-remote https://github.com/instill-ai/api-gateway.git HEAD | cut -c1-7) && \
-			PIPELINE_BACKEND_COMMIT_SHORT_SHA=$$(git ls-remote https://github.com/instill-ai/pipeline-backend.git HEAD | cut -c1-7) && \
-			ARTIFACT_BACKEND_COMMIT_SHORT_SHA=$$(git ls-remote https://github.com/instill-ai/artifact-backend.git HEAD | cut -c1-7) && \
-			MODEL_BACKEND_COMMIT_SHORT_SHA=$$(git ls-remote https://github.com/instill-ai/model-backend.git HEAD | cut -c1-7) && \
-			MGMT_BACKEND_COMMIT_SHORT_SHA=$$(git ls-remote https://github.com/instill-ai/mgmt-backend.git HEAD | cut -c1-7) && \
-			CONSOLE_COMMIT_SHORT_SHA=$$(git ls-remote https://github.com/instill-ai/console.git HEAD | cut -c1-7) && \
-		) \
 		docker build --progress plain \
 			--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
 			--build-arg K6_VERSION=${K6_VERSION} \
 			--build-arg XK6_VERSION=${XK6_VERSION} \
 			--build-arg XK6_SQL_VERSION=${XK6_SQL_VERSION} \
 			--build-arg XK6_SQL_POSTGRES_VERSION=${XK6_SQL_POSTGRES_VERSION} \
-			--build-arg CACHE_DATE="$(if $(filter latest,$(1)),$(shell date +%Y%m%d%H%M%S),$(shell date))" \
-			$(if $(filter latest,$(1)), \
-			--build-arg API_GATEWAY_COMMIT_SHORT_SHA=$$API_GATEWAY_COMMIT_SHORT_SHA \
-			--build-arg PIPELINE_BACKEND_COMMIT_SHORT_SHA=$$PIPELINE_BACKEND_COMMIT_SHORT_SHA \
-			--build-arg ARTIFACT_BACKEND_COMMIT_SHORT_SHA=$$ARTIFACT_BACKEND_COMMIT_SHORT_SHA \
-			--build-arg MODEL_BACKEND_COMMIT_SHORT_SHA=$$MODEL_BACKEND_COMMIT_SHORT_SHA \
-			--build-arg MGMT_BACKEND_COMMIT_SHORT_SHA=$$MGMT_BACKEND_COMMIT_SHORT_SHA \
-			--build-arg CONSOLE_COMMIT_SHORT_SHA=$$CONSOLE_COMMIT_SHORT_SHA) \
-			$(if $(filter release,$(1)), \
+			--build-arg CACHE_DATE="$(shell date)" \
 			--build-arg API_GATEWAY_VERSION=${API_GATEWAY_VERSION} \
 			--build-arg PIPELINE_BACKEND_VERSION=${PIPELINE_BACKEND_VERSION} \
 			--build-arg ARTIFACT_BACKEND_VERSION=${ARTIFACT_BACKEND_VERSION} \
 			--build-arg MODEL_BACKEND_VERSION=${MODEL_BACKEND_VERSION} \
 			--build-arg MGMT_BACKEND_VERSION=${MGMT_BACKEND_VERSION} \
-			--build-arg CONSOLE_VERSION=${CONSOLE_VERSION}) \
-			--target $(1) \
-			-t ${INSTILL_CORE_IMAGE_NAME}:$(1) . && \
-		if [ "$(BUILD_ALL_FROM_SOURCE)" = "true" ]; then \
-			docker run --rm \
-				-v /var/run/docker.sock:/var/run/docker.sock \
-				-v ./.env:/instill-core/.env \
-				-v ./docker-compose-build.yml:/instill-core/docker-compose-build.yml \
-				--name ${CONTAINER_BUILD_NAME}-$(1) \
-				${INSTILL_CORE_IMAGE_NAME}:$(1) /bin/sh -c " \
-					API_GATEWAY_SERVICE_NAME=$(API_GATEWAY_HOST) \
-					PIPELINE_BACKEND_SERVICE_NAME=$(PIPELINE_BACKEND_HOST) \
-					ARTIFACT_BACKEND_SERVICE_NAME=$(ARTIFACT_BACKEND_HOST) \
-					MODEL_BACKEND_SERVICE_NAME=$(MODEL_BACKEND_HOST) \
-					MGMT_BACKEND_SERVICE_NAME=$(MGMT_BACKEND_HOST) \
-					$(if $(filter release,$(1)), \
-					API_GATEWAY_VERSION=$(API_GATEWAY_VERSION) \
-					API_GATEWAY_SERVICE_VERSION=$(API_GATEWAY_VERSION) \
-					PIPELINE_BACKEND_VERSION=$(PIPELINE_BACKEND_VERSION) \
-					PIPELINE_BACKEND_SERVICE_VERSION=$(PIPELINE_BACKEND_VERSION) \
-					ARTIFACT_BACKEND_VERSION=$(ARTIFACT_BACKEND_VERSION) \
-					ARTIFACT_BACKEND_SERVICE_VERSION=$(ARTIFACT_BACKEND_VERSION) \
-					MODEL_BACKEND_VERSION=$(MODEL_BACKEND_VERSION) \
-					MODEL_BACKEND_SERVICE_VERSION=$(MODEL_BACKEND_VERSION) \
-					MGMT_BACKEND_VERSION=$(MGMT_BACKEND_VERSION) \
-					MGMT_BACKEND_SERVICE_VERSION=$(MGMT_BACKEND_VERSION) \
-					CONSOLE_VERSION=$(CONSOLE_VERSION)) \
-					$(if $(filter latest,$(1)), \
-					API_GATEWAY_VERSION=latest \
-					API_GATEWAY_SERVICE_VERSION=$$API_GATEWAY_COMMIT_SHORT_SHA \
-					PIPELINE_BACKEND_VERSION=latest \
-					PIPELINE_BACKEND_SERVICE_VERSION=$$PIPELINE_BACKEND_COMMIT_SHORT_SHA \
-					ARTIFACT_BACKEND_VERSION=latest \
-					ARTIFACT_BACKEND_SERVICE_VERSION=$$ARTIFACT_BACKEND_COMMIT_SHORT_SHA \
-					MODEL_BACKEND_VERSION=latest \
-					MODEL_BACKEND_SERVICE_VERSION=$$MODEL_BACKEND_COMMIT_SHORT_SHA \
-					MGMT_BACKEND_VERSION=latest \
-					MGMT_BACKEND_SERVICE_VERSION=$$MGMT_BACKEND_COMMIT_SHORT_SHA \
-					CONSOLE_VERSION=latest) \
-					docker compose -f docker-compose-build.yml build --pull \
-				"; \
-		fi \
+			--build-arg CONSOLE_VERSION=${CONSOLE_VERSION} \
+			-t ${INSTILL_CORE_IMAGE_NAME}:${GIT_COMMIT_SHA} . \
 	'
 endef
 
 # Function to remove containers
 define REMOVE_CONTAINERS
-	@docker rm -f ${CONTAINER_BUILD_NAME}-latest ${CONTAINER_BUILD_NAME}-release >/dev/null 2>&1
-	@docker rm -f ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}-latest ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}-release >/dev/null 2>&1
-	@docker rm -f ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}-helm-latest ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}-helm-release >/dev/null 2>&1
+	@docker rm -f ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}:${GIT_COMMIT_SHA} >/dev/null 2>&1
+	@docker rm -f ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}-helm:${GIT_COMMIT_SHA} >/dev/null 2>&1
 endef
 
 # Function to cleanup helm release
@@ -158,11 +100,11 @@ endef
 
 # Function to run backend integration test
 define COMPOSE_INTEGRATION_TEST
-	@$(MAKE) $(1) EDITION=docker-ce:test ENV_SECRETS_COMPONENT=${ENV_SECRETS_COMPONENT_TEST}
+	@$(MAKE) compose-run EDITION=docker-ce:test ENV_SECRETS_COMPONENT=${ENV_SECRETS_COMPONENT_TEST}
 	@docker run --rm \
 		--network ${COMPOSE_NETWORK_NAME} \
-		--name ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}-$(2) \
-		${INSTILL_CORE_IMAGE_NAME}:$(2) /bin/sh -c " \
+		--name ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}-${GIT_COMMIT_SHA} \
+		${INSTILL_CORE_IMAGE_NAME}:${GIT_COMMIT_SHA} /bin/sh -c " \
 			/bin/sh -c 'cd mgmt-backend && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' && \
 			/bin/sh -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT} DB_HOST=pg-sql' && \
 			/bin/sh -c 'cd model-backend && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' \
@@ -172,7 +114,7 @@ endef
 
 # Function to run Helm backend integration test
 define HELM_INTEGRATION_TEST
-	@$(MAKE) helm-$(1) CI=true
+	@$(MAKE) helm CI=true
 	@bash -c 'while [[ "$$(kubectl get pods --namespace ${HELM_NAMESPACE} -l app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=core -o jsonpath={..status.phase})" != *"Running"* ]]; do \
 		echo "$$(kubectl get pods --namespace ${HELM_NAMESPACE})"; \
 		sleep 10; \
@@ -181,7 +123,7 @@ define HELM_INTEGRATION_TEST
 	@kubectl --namespace ${HELM_NAMESPACE} port-forward $$(kubectl get pods --namespace ${HELM_NAMESPACE} -l "app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=core" -o jsonpath="{.items[0].metadata.name}") ${API_GATEWAY_PORT}:${API_GATEWAY_PORT} > /dev/null 2>&1 &
 	@kubectl --namespace ${HELM_NAMESPACE} port-forward $$(kubectl get pods --namespace ${HELM_NAMESPACE} -l "app.kubernetes.io/component=database,app.kubernetes.io/instance=core" -o jsonpath="{.items[0].metadata.name}") ${POSTGRESQL_PORT}:${POSTGRESQL_PORT} > /dev/null 2>&1 &
 	@echo "Waiting for port-forwarding to be ready..."
-	@timeout=60; \
+	@timeout=120; \
 		while ! nc -z localhost ${API_GATEWAY_PORT} >/dev/null 2>&1 || ! nc -z localhost ${POSTGRESQL_PORT} >/dev/null 2>&1; do \
 			if [ $$timeout -le 0 ]; then \
 				echo "Timeout waiting for port-forwarding"; \
@@ -192,26 +134,29 @@ define HELM_INTEGRATION_TEST
 		done;
 	@echo "Port-forwarding is ready"
 	@if [ "$(UNAME_S)" = "Darwin" ]; then \
-		docker run --rm --name ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}-helm-$(1) ${INSTILL_CORE_IMAGE_NAME}:$(1) /bin/sh -c " \
+		docker run --rm --name ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}-helm-${GIT_COMMIT_SHA} ${INSTILL_CORE_IMAGE_NAME}:${GIT_COMMIT_SHA} /bin/sh -c " \
 			/bin/sh -c 'cd mgmt-backend && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' && \
 			/bin/sh -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT} DB_HOST=host.docker.internal' && \
 			/bin/sh -c 'cd model-backend && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' \
 		"; \
 	else \
-		docker run --rm --network host --name ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}-helm-$(1) ${INSTILL_CORE_IMAGE_NAME}:$(1) /bin/sh -c " \
+		docker run --rm --network host --name ${CONTAINER_COMPOSE_INTEGRATION_TEST_NAME}-helm-${GIT_COMMIT_SHA} ${INSTILL_CORE_IMAGE_NAME}:${GIT_COMMIT_SHA} /bin/sh -c " \
 			/bin/sh -c 'cd mgmt-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' && \
 			/bin/sh -c 'cd pipeline-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' && \
 			/bin/sh -c 'cd model-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' \
 		"; \
 	fi
 	@$(MAKE) down
+	@echo "Cleaning up port-forwarding processes on ports ${API_GATEWAY_PORT} and ${POSTGRESQL_PORT}..."
+	@lsof -ti:${API_GATEWAY_PORT} | xargs -r kill -9 2>/dev/null || true
+	@lsof -ti:${POSTGRESQL_PORT} | xargs -r kill -9 2>/dev/null || true
 endef
 
 # Function to run model deployment integration test
 define MODEL_INTEGRATION_TEST
 	@EDITION=docker-ce:test docker compose up registry -d
 	@$(MAKE) build-and-push-models
-	@$(MAKE) $(1) EDITION=docker-ce:test INITMODEL_ENABLED=true INITMODEL_INVENTORY=${PWD}/integration-test/models/inventory.json
+	@$(MAKE) compose-run EDITION=docker-ce:test INITMODEL_ENABLED=true INITMODEL_INVENTORY=${PWD}/integration-test/models/inventory.json
 	@$(MAKE) wait-models-deploy
 	@$(MAKE) down
 endef

--- a/Makefile.helper
+++ b/Makefile.helper
@@ -114,7 +114,7 @@ endef
 
 # Function to run Helm backend integration test
 define HELM_INTEGRATION_TEST
-	@$(MAKE) helm CI=true
+	@$(MAKE) helm-run CI=true
 	@bash -c 'while [[ "$$(kubectl get pods --namespace ${HELM_NAMESPACE} -l app.kubernetes.io/component=api-gateway,app.kubernetes.io/instance=core -o jsonpath={..status.phase})" != *"Running"* ]]; do \
 		echo "$$(kubectl get pods --namespace ${HELM_NAMESPACE})"; \
 		sleep 10; \

--- a/Makefile.helper
+++ b/Makefile.helper
@@ -58,8 +58,8 @@ define HELM
 		--timeout 30m0s
 endef
 
-# Function to build image
-define BUILD_TEST
+# Function to build dev image
+define BUILD_DEV
 	@bash -c ' \
 		set -e; \
 		trap "$(MAKE) down" ERR INT TERM && \

--- a/Makefile.helper
+++ b/Makefile.helper
@@ -1,7 +1,7 @@
 # Helper functions for common make targets
 
 # Function to ensure user_uid exists
-define ensure_user_uid
+define ENSURE_USER_UID
 	@if [ ! -f "$$(echo ${SYSTEM_CONFIG_PATH}/user_uid)" ]; then \
 		mkdir -p ${SYSTEM_CONFIG_PATH} && \
 		uuidgen > ${SYSTEM_CONFIG_PATH}/user_uid; \

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Execute the following commands to pull pre-built images with all the dependencie
 $ git clone -b v0.53.0 https://github.com/instill-ai/instill-core.git && cd instill-core
 
 # Launch all services
-$ make all
+$ make compose-run
 ```
 <!-- x-release-please-end -->
 
@@ -75,7 +75,7 @@ Execute the following commands to build images with all the dependencies to laun
 $ git clone https://github.com/instill-ai/instill-core.git && cd instill-core
 
 # Launch all services
-$ make latest
+$ make compose-dev
 ```
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 [![Integration Test](https://img.shields.io/github/actions/workflow/status/instill-ai/instill-core/integration-test.yml?branch=main&label=Integration%20Test&logoColor=fff&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wIDEuNzVDMCAwLjc4NCAwLjc4NCAwIDEuNzUgMEg1LjI1QzYuMjE2IDAgNyAwLjc4NCA3IDEuNzVWNS4yNUM3IDUuNzE0MTMgNi44MTU2MyA2LjE1OTI1IDYuNDg3NDQgNi40ODc0NEM2LjE1OTI1IDYuODE1NjMgNS43MTQxMyA3IDUuMjUgN0g0VjExQzQgMTEuMjY1MiA0LjEwNTM2IDExLjUxOTYgNC4yOTI4OSAxMS43MDcxQzQuNDgwNDMgMTEuODk0NiA0LjczNDc4IDEyIDUgMTJIOVYxMC43NUM5IDkuNzg0IDkuNzg0IDkgMTAuNzUgOUgxNC4yNUMxNS4yMTYgOSAxNiA5Ljc4NCAxNiAxMC43NVYxNC4yNUMxNiAxNC43MTQxIDE1LjgxNTYgMTUuMTU5MiAxNS40ODc0IDE1LjQ4NzRDMTUuMTU5MiAxNS44MTU2IDE0LjcxNDEgMTYgMTQuMjUgMTZIMTAuNzVDMTAuMjg1OSAxNiA5Ljg0MDc1IDE1LjgxNTYgOS41MTI1NiAxNS40ODc0QzkuMTg0MzcgMTUuMTU5MiA5IDE0LjcxNDEgOSAxNC4yNVYxMy41SDVDNC4zMzY5NiAxMy41IDMuNzAxMDcgMTMuMjM2NiAzLjIzMjIzIDEyLjc2NzhDMi43NjMzOSAxMi4yOTg5IDIuNSAxMS42NjMgMi41IDExVjdIMS43NUMxLjI4NTg3IDcgMC44NDA3NTIgNi44MTU2MyAwLjUxMjU2MyA2LjQ4NzQ0QzAuMTg0Mzc0IDYuMTU5MjUgMCA1LjcxNDEzIDAgNS4yNUwwIDEuNzVaTTEuNzUgMS41QzEuNjgzNyAxLjUgMS42MjAxMSAxLjUyNjM0IDEuNTczMjIgMS41NzMyMkMxLjUyNjM0IDEuNjIwMTEgMS41IDEuNjgzNyAxLjUgMS43NVY1LjI1QzEuNSA1LjM4OCAxLjYxMiA1LjUgMS43NSA1LjVINS4yNUM1LjMxNjMgNS41IDUuMzc5ODkgNS40NzM2NiA1LjQyNjc4IDUuNDI2NzhDNS40NzM2NiA1LjM3OTg5IDUuNSA1LjMxNjMgNS41IDUuMjVWMS43NUM1LjUgMS42ODM3IDUuNDczNjYgMS42MjAxMSA1LjQyNjc4IDEuNTczMjJDNS4zNzk4OSAxLjUyNjM0IDUuMzE2MyAxLjUgNS4yNSAxLjVIMS43NVpNMTAuNzUgMTAuNUMxMC42ODM3IDEwLjUgMTAuNjIwMSAxMC41MjYzIDEwLjU3MzIgMTAuNTczMkMxMC41MjYzIDEwLjYyMDEgMTAuNSAxMC42ODM3IDEwLjUgMTAuNzVWMTQuMjVDMTAuNSAxNC4zODggMTAuNjEyIDE0LjUgMTAuNzUgMTQuNUgxNC4yNUMxNC4zMTYzIDE0LjUgMTQuMzc5OSAxNC40NzM3IDE0LjQyNjggMTQuNDI2OEMxNC40NzM3IDE0LjM3OTkgMTQuNSAxNC4zMTYzIDE0LjUgMTQuMjVWMTAuNzVDMTQuNSAxMC42ODM3IDE0LjQ3MzcgMTAuNjIwMSAxNC40MjY4IDEwLjU3MzJDMTQuMzc5OSAxMC41MjYzIDE0LjMxNjMgMTAuNSAxNC4yNSAxMC41SDEwLjc1WiIgZmlsbD0id2hpdGUiLz4KPC9zdmc+Cg==)](https://github.com/instill-ai/instill-core/actions/workflows/integration-test-latest.yml?branch=main&event=push)
 [![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/instill-ai/instill-core?&label=Release&color=blue&include_prereleases&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTQgOEg3VjRIMjNWMTdIMjFDMjEgMTguNjYgMTkuNjYgMjAgMTggMjBDMTYuMzQgMjAgMTUgMTguNjYgMTUgMTdIOUM5IDE4LjY2IDcuNjYgMjAgNiAyMEM0LjM0IDIwIDMgMTguNjYgMyAxN0gxVjEyTDQgOFpNMTggMThDMTguNTUgMTggMTkgMTcuNTUgMTkgMTdDMTkgMTYuNDUgMTguNTUgMTYgMTggMTZDMTcuNDUgMTYgMTcgMTYuNDUgMTcgMTdDMTcgMTcuNTUgMTcuNDUgMTggMTggMThaTTQuNSA5LjVMMi41NCAxMkg3VjkuNUg0LjVaTTYgMThDNi41NSAxOCA3IDE3LjU1IDcgMTdDNyAxNi40NSA2LjU1IDE2IDYgMTZDNS40NSAxNiA1IDE2LjQ1IDUgMTdDNSAxNy41NSA1LjQ1IDE4IDYgMThaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K)](https://github.com/instill-ai/instill-core/releases)
 [![Artifact Hub](https://img.shields.io/endpoint?labelColor=gray&color=blue&url=https://artifacthub.io/badge/repository/instill-ai)](https://artifacthub.io/packages/helm/instill-ai/core)
-[![Discord](https://img.shields.io/discord/928991293856681984?color=blue&label=Discord&logo=discord&logoColor=fff)](https://discord.gg/sevxWsqpGh) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-31-blue.svg?label=All%20Contributors)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
+[![Discord](https://img.shields.io/discord/928991293856681984?color=blue&label=Discord&logo=discord&logoColor=fff)](https://discord.gg/sevxWsqpGh) <!--
 
 A complete unstructured data solution: ETL processing, AI-readiness, open-source LLM hosting, and RAG capabilities in one powerful platform.
 
@@ -41,7 +39,6 @@ Follow the [installation](#installation) steps below or [documentation](https://
 
 See [Examples](https://www.instill-ai.dev/docs/examples) for more!
 
-
 ## Installation
 
 ### Prerequisites
@@ -52,36 +49,20 @@ See [Examples](https://www.instill-ai.dev/docs/examples) for more!
 | Windows          | • Use Windows Subsystem for Linux (WSL2)<br>• Install latest `yq` from [GitHub Repository](https://github.com/mikefarah/yq)<br>• Install latest Docker Desktop and enable WSL2 integration ([tutorial](https://docs.docker.com/desktop/wsl))<br>• (Optional) Install `cuda-toolkit` on WSL2 ([NVIDIA tutorial](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#getting-started-with-cuda-on-wsl-2)) |
 | All Systems      | • Docker Engine v25 or later<br>• Docker Compose v2 or later<br>• Install latest stable [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)                                                                                                                                                                                                       |
 
-### Steps
-
-#### Use stable release version
+### Spin up Instill Core
 
 Execute the following commands to pull pre-built images with all the dependencies to launch:
 
 <!-- x-release-please-start-version -->
 ```bash
-$ git clone -b v0.53.0 https://github.com/instill-ai/instill-core.git && cd instill-core
+git clone -b v0.53.0 https://github.com/instill-ai/instill-core.git && cd instill-core
 
 # Launch all services
-$ make compose-run
+make run
 ```
 <!-- x-release-please-end -->
 
-#### Use the latest version for local development
-
-Execute the following commands to build images with all the dependencies to launch:
-
-```bash
-$ git clone https://github.com/instill-ai/instill-core.git && cd instill-core
-
-# Launch all services
-$ make compose-dev
-```
-
-> [!IMPORTANT]
-> Code in the main branch tracks under-development progress towards the next release and may not work as expected. If you are looking for a stable alpha version, please use [latest release](https://github.com/instill-ai/instill-core/releases).
-
-🚀 That's it! Once all the services are up with health status, the UI is ready to go at <http://localhost:3000>. Please find the default login credentials in the [documentation](https://www.instill-ai.dev/docs/latest/quickstart#self-hosted-instill-core).
+That's it! Once all the services are up with health status, the UI is ready to go at <http://localhost:3000>. Please find the default login credentials in the [documentation](https://www.instill-ai.dev/docs/latest/quickstart#self-hosted-instill-core).
 
 To shut down all running services:
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,6 +1,5 @@
 services:
   api_gateway:
-    image: ${API_GATEWAY_IMAGE}:latest
     environment:
       LOG_LEVEL: DEBUG
     ports:
@@ -9,7 +8,6 @@ services:
       - ${API_GATEWAY_METRICS_HOST_PORT}:${API_GATEWAY_METRICS_PORT}
 
   pipeline_backend:
-    image: ${PIPELINE_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
       CFG_SERVER_EDITION: ${EDITION}
@@ -18,13 +16,11 @@ services:
       - ${PIPELINE_BACKEND_HOST_PUBLICPORT}:${PIPELINE_BACKEND_PUBLICPORT}
 
   pipeline_backend_worker:
-    image: ${PIPELINE_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
       CFG_SERVER_EDITION: ${EDITION}
 
   artifact_backend:
-    image: ${ARTIFACT_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
       CFG_SERVER_EDITION: ${EDITION}
@@ -33,7 +29,6 @@ services:
       - ${ARTIFACT_BACKEND_HOST_PUBLICPORT}:${ARTIFACT_BACKEND_PUBLICPORT}
 
   model_backend:
-    image: ${MODEL_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
       CFG_SERVER_EDITION: ${EDITION}
@@ -41,16 +36,11 @@ services:
       - ${MODEL_BACKEND_HOST_PRIVATEPORT}:${MODEL_BACKEND_PRIVATEPORT}
       - ${MODEL_BACKEND_HOST_PUBLICPORT}:${MODEL_BACKEND_PUBLICPORT}
 
-  model_backend_init_model:
-    image: ${MODEL_BACKEND_IMAGE}:latest
-
   model_backend_worker:
-    image: ${MODEL_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
 
   mgmt_backend:
-    image: ${MGMT_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
       CFG_SERVER_EDITION: ${EDITION}
@@ -59,13 +49,11 @@ services:
       - ${MGMT_BACKEND_HOST_PUBLICPORT}:${MGMT_BACKEND_PUBLICPORT}
 
   mgmt_backend_worker:
-    image: ${MGMT_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
       CFG_SERVER_EDITION: ${EDITION}
 
   console:
-    image: ${CONSOLE_IMAGE}:latest
     environment:
       NEXT_PUBLIC_USAGE_COLLECTION_ENABLED: ${USAGE_ENABLED}
       NEXT_PUBLIC_CONSOLE_EDITION: ${EDITION}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -68,7 +68,6 @@ services:
       - ${TEMPORAL_UI_HOST_PORT}:${TEMPORAL_UI_PORT}
 
   ray:
-    image: ${RAY_IMAGE}:${RAY_LATEST_TAG}
     ports:
       - ${RAY_DASHBOARD_HOST_PORT}:${RAY_PORT_DASHBOARD}
 


### PR DESCRIPTION
Because

- we want to make the `instill-core` service dependencies clearer and more traceable. To achieve this, we will retire the use of the `latest` image tag for each service. All services must now provide a Git tag or commit hash as the version.
- with the retirement of the `latest` tag, there's no longer a need to maintain separate release/latest scripts, so we will merge them.

This commit

- simplifies deployment by using the Git commit hash as the service version.
- renames `docker-compose-latest.yml` to `docker-compose-dev.yml` to better reflect its purpose for development.
- merges all release/latest scripts into unified ones. For example:
  - `make latest`, `make all` → `make compose-run`
  - `make compose-integration-test-latest`, `make compose-integration-test-release` → `make compose-integration-test`