### PR TITLE
ci(compose): increase mgmt-backend healthcheck start_period

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -341,7 +341,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 60
-      start_period: 20s
+      start_period: 60s
     depends_on:
       mgmt_backend_worker:
         condition: service_started


### PR DESCRIPTION
Because

- `mgmt-backend` main and worker binary take a bit of times to reconcile.

This commit

- increase `start_period` in healthcheck.
