### PR TITLE
ci(compose): rename env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,37 +32,37 @@ RUN echo "Instill Core latest codebase cloned on ${CACHE_DATE}"
 
 WORKDIR /instill-core
 
-ARG API_GATEWAY_COMMIT_SHORT_HASH
-ARG PIPELINE_BACKEND_COMMIT_SHORT_HASH
-ARG ARTIFACT_BACKEND_COMMIT_SHORT_HASH
-ARG MODEL_BACKEND_COMMIT_SHORT_HASH
-ARG MGMT_BACKEND_COMMIT_SHORT_HASH
-ARG CONSOLE_COMMIT_SHORT_HASH
+ARG API_GATEWAY_COMMIT_SHORT_SHA
+ARG PIPELINE_BACKEND_COMMIT_SHORT_SHA
+ARG ARTIFACT_BACKEND_COMMIT_SHORT_SHA
+ARG MODEL_BACKEND_COMMIT_SHORT_SHA
+ARG MGMT_BACKEND_COMMIT_SHORT_SHA
+ARG CONSOLE_COMMIT_SHORT_SHA
 
 RUN git clone --depth=1 https://github.com/instill-ai/api-gateway.git
-RUN cd api-gateway && git config advice.detachedHead false && git fetch origin && git checkout ${API_GATEWAY_COMMIT_SHORT_HASH}
+RUN cd api-gateway && git config advice.detachedHead false && git fetch origin && git checkout ${API_GATEWAY_COMMIT_SHORT_SHA}
 
 RUN git clone --depth=1 https://github.com/instill-ai/pipeline-backend.git
-RUN cd pipeline-backend && git config advice.detachedHead false && git fetch origin && git checkout ${PIPELINE_BACKEND_COMMIT_SHORT_HASH}
+RUN cd pipeline-backend && git config advice.detachedHead false && git fetch origin && git checkout ${PIPELINE_BACKEND_COMMIT_SHORT_SHA}
 
 RUN git clone --depth=1 https://github.com/instill-ai/artifact-backend.git
-RUN cd artifact-backend && git config advice.detachedHead false && git fetch origin && git checkout ${ARTIFACT_BACKEND_COMMIT_SHORT_HASH}
+RUN cd artifact-backend && git config advice.detachedHead false && git fetch origin && git checkout ${ARTIFACT_BACKEND_COMMIT_SHORT_SHA}
 
 RUN git clone --depth=1 https://github.com/instill-ai/model-backend.git
-RUN cd model-backend && git config advice.detachedHead false && git fetch origin && git checkout ${MODEL_BACKEND_COMMIT_SHORT_HASH}
+RUN cd model-backend && git config advice.detachedHead false && git fetch origin && git checkout ${MODEL_BACKEND_COMMIT_SHORT_SHA}
 
 RUN git clone --depth=1 https://github.com/instill-ai/mgmt-backend.git
-RUN cd mgmt-backend && git config advice.detachedHead false && git fetch origin && git checkout ${MGMT_BACKEND_COMMIT_SHORT_HASH}
+RUN cd mgmt-backend && git config advice.detachedHead false && git fetch origin && git checkout ${MGMT_BACKEND_COMMIT_SHORT_SHA}
 
 RUN git clone --depth=1 https://github.com/instill-ai/console.git
-RUN cd console && git config advice.detachedHead false && git fetch origin && git checkout ${CONSOLE_COMMIT_SHORT_HASH}
+RUN cd console && git config advice.detachedHead false && git fetch origin && git checkout ${CONSOLE_COMMIT_SHORT_SHA}
 
-ENV API_GATEWAY_VERSION=${API_GATEWAY_COMMIT_SHORT_HASH}
-ENV PIPELINE_BACKEND_VERSION=${PIPELINE_BACKEND_COMMIT_SHORT_HASH}
-ENV ARTIFACT_BACKEND_VERSION=${ARTIFACT_BACKEND_COMMIT_SHORT_HASH}
-ENV MODEL_BACKEND_VERSION=${MODEL_BACKEND_COMMIT_SHORT_HASH}
-ENV MGMT_BACKEND_VERSION=${MGMT_BACKEND_COMMIT_SHORT_HASH}
-ENV CONSOLE_VERSION=${CONSOLE_COMMIT_SHORT_HASH}
+ENV API_GATEWAY_VERSION=${API_GATEWAY_COMMIT_SHORT_SHA}
+ENV PIPELINE_BACKEND_VERSION=${PIPELINE_BACKEND_COMMIT_SHORT_SHA}
+ENV ARTIFACT_BACKEND_VERSION=${ARTIFACT_BACKEND_COMMIT_SHORT_SHA}
+ENV MODEL_BACKEND_VERSION=${MODEL_BACKEND_COMMIT_SHORT_SHA}
+ENV MGMT_BACKEND_VERSION=${MGMT_BACKEND_COMMIT_SHORT_SHA}
+ENV CONSOLE_VERSION=${CONSOLE_COMMIT_SHORT_SHA}
 
 FROM alpine:${ALPINE_VERSION} AS release
 

--- a/Makefile.helper
+++ b/Makefile.helper
@@ -65,12 +65,12 @@ define BUILD
 		set -e; \
 		trap "$(MAKE) down" ERR INT TERM && \
 		$(if $(filter latest,$(1)), \
-			API_GATEWAY_COMMIT_SHORT_HASH=$$(git ls-remote https://github.com/instill-ai/api-gateway.git HEAD | cut -c1-7) && \
-			PIPELINE_BACKEND_COMMIT_SHORT_HASH=$$(git ls-remote https://github.com/instill-ai/pipeline-backend.git HEAD | cut -c1-7) && \
-			ARTIFACT_BACKEND_COMMIT_SHORT_HASH=$$(git ls-remote https://github.com/instill-ai/artifact-backend.git HEAD | cut -c1-7) && \
-			MODEL_BACKEND_COMMIT_SHORT_HASH=$$(git ls-remote https://github.com/instill-ai/model-backend.git HEAD | cut -c1-7) && \
-			MGMT_BACKEND_COMMIT_SHORT_HASH=$$(git ls-remote https://github.com/instill-ai/mgmt-backend.git HEAD | cut -c1-7) && \
-			CONSOLE_COMMIT_SHORT_HASH=$$(git ls-remote https://github.com/instill-ai/console.git HEAD | cut -c1-7) && \
+			API_GATEWAY_COMMIT_SHORT_SHA=$$(git ls-remote https://github.com/instill-ai/api-gateway.git HEAD | cut -c1-7) && \
+			PIPELINE_BACKEND_COMMIT_SHORT_SHA=$$(git ls-remote https://github.com/instill-ai/pipeline-backend.git HEAD | cut -c1-7) && \
+			ARTIFACT_BACKEND_COMMIT_SHORT_SHA=$$(git ls-remote https://github.com/instill-ai/artifact-backend.git HEAD | cut -c1-7) && \
+			MODEL_BACKEND_COMMIT_SHORT_SHA=$$(git ls-remote https://github.com/instill-ai/model-backend.git HEAD | cut -c1-7) && \
+			MGMT_BACKEND_COMMIT_SHORT_SHA=$$(git ls-remote https://github.com/instill-ai/mgmt-backend.git HEAD | cut -c1-7) && \
+			CONSOLE_COMMIT_SHORT_SHA=$$(git ls-remote https://github.com/instill-ai/console.git HEAD | cut -c1-7) && \
 		) \
 		docker build --progress plain \
 			--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
@@ -80,12 +80,12 @@ define BUILD
 			--build-arg XK6_SQL_POSTGRES_VERSION=${XK6_SQL_POSTGRES_VERSION} \
 			--build-arg CACHE_DATE="$(if $(filter latest,$(1)),$(shell date +%Y%m%d%H%M%S),$(shell date))" \
 			$(if $(filter latest,$(1)), \
-			--build-arg API_GATEWAY_COMMIT_SHORT_HASH=$$API_GATEWAY_COMMIT_SHORT_HASH \
-			--build-arg PIPELINE_BACKEND_COMMIT_SHORT_HASH=$$PIPELINE_BACKEND_COMMIT_SHORT_HASH \
-			--build-arg ARTIFACT_BACKEND_COMMIT_SHORT_HASH=$$ARTIFACT_BACKEND_COMMIT_SHORT_HASH \
-			--build-arg MODEL_BACKEND_COMMIT_SHORT_HASH=$$MODEL_BACKEND_COMMIT_SHORT_HASH \
-			--build-arg MGMT_BACKEND_COMMIT_SHORT_HASH=$$MGMT_BACKEND_COMMIT_SHORT_HASH \
-			--build-arg CONSOLE_COMMIT_SHORT_HASH=$$CONSOLE_COMMIT_SHORT_HASH) \
+			--build-arg API_GATEWAY_COMMIT_SHORT_SHA=$$API_GATEWAY_COMMIT_SHORT_SHA \
+			--build-arg PIPELINE_BACKEND_COMMIT_SHORT_SHA=$$PIPELINE_BACKEND_COMMIT_SHORT_SHA \
+			--build-arg ARTIFACT_BACKEND_COMMIT_SHORT_SHA=$$ARTIFACT_BACKEND_COMMIT_SHORT_SHA \
+			--build-arg MODEL_BACKEND_COMMIT_SHORT_SHA=$$MODEL_BACKEND_COMMIT_SHORT_SHA \
+			--build-arg MGMT_BACKEND_COMMIT_SHORT_SHA=$$MGMT_BACKEND_COMMIT_SHORT_SHA \
+			--build-arg CONSOLE_COMMIT_SHORT_SHA=$$CONSOLE_COMMIT_SHORT_SHA) \
 			$(if $(filter release,$(1)), \
 			--build-arg API_GATEWAY_VERSION=${API_GATEWAY_VERSION} \
 			--build-arg PIPELINE_BACKEND_VERSION=${PIPELINE_BACKEND_VERSION} \
@@ -121,15 +121,15 @@ define BUILD
 					CONSOLE_VERSION=$(CONSOLE_VERSION)) \
 					$(if $(filter latest,$(1)), \
 					API_GATEWAY_VERSION=latest \
-					API_GATEWAY_SERVICE_VERSION=$$API_GATEWAY_COMMIT_SHORT_HASH \
+					API_GATEWAY_SERVICE_VERSION=$$API_GATEWAY_COMMIT_SHORT_SHA \
 					PIPELINE_BACKEND_VERSION=latest \
-					PIPELINE_BACKEND_SERVICE_VERSION=$$PIPELINE_BACKEND_COMMIT_SHORT_HASH \
+					PIPELINE_BACKEND_SERVICE_VERSION=$$PIPELINE_BACKEND_COMMIT_SHORT_SHA \
 					ARTIFACT_BACKEND_VERSION=latest \
-					ARTIFACT_BACKEND_SERVICE_VERSION=$$ARTIFACT_BACKEND_COMMIT_SHORT_HASH \
+					ARTIFACT_BACKEND_SERVICE_VERSION=$$ARTIFACT_BACKEND_COMMIT_SHORT_SHA \
 					MODEL_BACKEND_VERSION=latest \
-					MODEL_BACKEND_SERVICE_VERSION=$$MODEL_BACKEND_COMMIT_SHORT_HASH \
+					MODEL_BACKEND_SERVICE_VERSION=$$MODEL_BACKEND_COMMIT_SHORT_SHA \
 					MGMT_BACKEND_VERSION=latest \
-					MGMT_BACKEND_SERVICE_VERSION=$$MGMT_BACKEND_COMMIT_SHORT_HASH \
+					MGMT_BACKEND_SERVICE_VERSION=$$MGMT_BACKEND_COMMIT_SHORT_SHA \
 					CONSOLE_VERSION=latest) \
 					docker compose -f docker-compose-build.yml build --pull \
 				"; \


### PR DESCRIPTION
Because

- make short commit SHA naming consistent across all places.

This commit

- replaces `COMMIT_SHORT_HASH` with `COMMIT_SHORT_SHA`
