### PR TITLE
ci(compose): fix mgmt-backend service order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -343,7 +343,13 @@ services:
       retries: 60
       start_period: 120s
     depends_on:
-      mgmt_backend_worker:
+      pg_sql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      temporal:
+        condition: service_healthy
+      openfga:
         condition: service_started
 
   mgmt_backend_worker:
@@ -367,14 +373,8 @@ services:
       CFG_INFLUXDB_URL: http://${INFLUXDB_HOST}:${INFLUXDB_PORT}
     entrypoint: ./mgmt-backend-worker
     depends_on:
-      pg_sql:
+      mgmt_backend:
         condition: service_healthy
-      redis:
-        condition: service_healthy
-      temporal:
-        condition: service_healthy
-      openfga:
-        condition: service_started
 
   console:
     pull_policy: missing


### PR DESCRIPTION
Because

- the mgmt-worker should start after mgmt-backend.

This commit

- swaps the service order.