### PR TITLE
ci(github): use a fixed length of commit sha

### DIFF
--- a/.github/workflows/update-service-version.yml
+++ b/.github/workflows/update-service-version.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Get short commit hash
         id: commit-hash
-        run: echo "short_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "short_hash=$(git rev-parse --short --short=7 HEAD)" >> $GITHUB_OUTPUT
 
       - name: Get commit messages between versions
         id: commit-messages

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ENV_SECRETS_CONSOLE := .env.secrets.console
 # Configuration directory path
 CONFIG_DIR_PATH := ./configs
 
-GIT_COMMIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null)
+GIT_COMMIT_SHA := $(shell git rev-parse --short --short=7 HEAD 2>/dev/null)
 
 #============================================================================
 


### PR DESCRIPTION
Because

- we need to control the length of commit sha

This commit

- uses a fixed length of commit sha
