### PR TITLE
ci(compose): increase ray healthcheck start_period

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -465,7 +465,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 60
-      start_period: 20s
+      start_period: 120s
 
   pg_sql:
     container_name: ${POSTGRESQL_HOST}


### PR DESCRIPTION
Because

- within a resource limited GA runner, `ray` service can take time to become healthy.

This commit

- increases ray service's healthcheck `start_period`.
