### PR TITLE
ci(github): update the service image tag in Helm chart automatically

### DIFF
--- a/.github/workflows/update-service-version.yml
+++ b/.github/workflows/update-service-version.yml
@@ -33,30 +33,37 @@ jobs:
             "api-gateway")
               echo "repository=api-gateway" >> $GITHUB_OUTPUT
               echo "version_var=API_GATEWAY_VERSION" >> $GITHUB_OUTPUT
+              echo "helm_path=apiGateway.image.tag" >> $GITHUB_OUTPUT
               ;;
             "mgmt")
               echo "repository=mgmt-backend" >> $GITHUB_OUTPUT
               echo "version_var=MGMT_BACKEND_VERSION" >> $GITHUB_OUTPUT
+              echo "helm_path=mgmtBackend.image.tag" >> $GITHUB_OUTPUT
               ;;
             "pipeline")
               echo "repository=pipeline-backend" >> $GITHUB_OUTPUT
               echo "version_var=PIPELINE_BACKEND_VERSION" >> $GITHUB_OUTPUT
+              echo "helm_path=pipelineBackend.image.tag" >> $GITHUB_OUTPUT
               ;;
             "artifact")
               echo "repository=artifact-backend" >> $GITHUB_OUTPUT
               echo "version_var=ARTIFACT_BACKEND_VERSION" >> $GITHUB_OUTPUT
+              echo "helm_path=artifactBackend.image.tag" >> $GITHUB_OUTPUT
               ;;
             "model")
               echo "repository=model-backend" >> $GITHUB_OUTPUT
               echo "version_var=MODEL_BACKEND_VERSION" >> $GITHUB_OUTPUT
+              echo "helm_path=modelBackend.image.tag" >> $GITHUB_OUTPUT
               ;;
             "ray")
               echo "repository=ray" >> $GITHUB_OUTPUT
               echo "version_var=RAY_VERSION" >> $GITHUB_OUTPUT
+              echo "helm_path=ray.image.tag" >> $GITHUB_OUTPUT
               ;;
             "console")
               echo "repository=console" >> $GITHUB_OUTPUT
               echo "version_var=CONSOLE_VERSION" >> $GITHUB_OUTPUT
+              echo "helm_path=console.image.tag" >> $GITHUB_OUTPUT
               ;;
           esac
 
@@ -123,15 +130,24 @@ jobs:
           repository: instill-ai/instill-core
           token: ${{ secrets.botGitHubToken }}
 
+      - name: Install yq - portable yaml processor
+        uses: mikefarah/yq@v4
+        with:
+          cmd: yq --version
 
       - name: Update service version
         run: |
           # Update the service version in .env file
           sed -i "s/${{ steps.service-config.outputs.version_var }}=.*/${{ steps.service-config.outputs.version_var }}=${{ steps.commit-hash.outputs.short_hash }}/" .env
 
-          # Verify the change
+          # Update the image tag in helm chart values.yaml
+          yq eval '.${{ steps.service-config.outputs.helm_path }} = "${{ steps.commit-hash.outputs.short_hash }}"' -i charts/core/values.yaml
+
+          # Verify the changes
           echo "Updated ${{ steps.service-config.outputs.version_var }} to: ${{ steps.commit-hash.outputs.short_hash }}"
           grep "${{ steps.service-config.outputs.version_var }}=" .env
+          echo "Updated helm chart ${{ steps.service-config.outputs.helm_path }} to: ${{ steps.commit-hash.outputs.short_hash }}"
+          yq eval '.${{ steps.service-config.outputs.helm_path }}' charts/core/values.yaml
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
@@ -144,7 +160,8 @@ jobs:
             - The version of the ${{ steps.service-config.outputs.repository }} service is not updated in the instill-core repository.
 
             This commit
-            - updates the `${{ steps.service-config.outputs.version_var }}` in the `.env` file from `${{ steps.current-version.outputs.current_version }}` to `${{ steps.commit-hash.outputs.short_hash }}`.
+            - updates the `${{ steps.service-config.outputs.version_var }}` in the `.env` file to `${{ steps.commit-hash.outputs.short_hash }}`.
+            - updates the `${{ steps.service-config.outputs.helm_path }}` in the helm chart values.yaml file to `${{ steps.commit-hash.outputs.short_hash }}`.
 
             ## Changes in ${{ steps.service-config.outputs.repository }}
             ${{ steps.commit-messages.outputs.commit_messages }}

--- a/.github/workflows/update-service-version.yml
+++ b/.github/workflows/update-service-version.yml
@@ -150,7 +150,7 @@ jobs:
           yq eval '.${{ steps.service-config.outputs.helm_path }}' charts/core/values.yaml
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.botGitHubToken }}
           commit-message: "chore(env): update ${{ steps.service-config.outputs.version_var }}"

--- a/.github/workflows/update-service-version.yml
+++ b/.github/workflows/update-service-version.yml
@@ -58,7 +58,7 @@ jobs:
             "ray")
               echo "repository=ray" >> $GITHUB_OUTPUT
               echo "version_var=RAY_VERSION" >> $GITHUB_OUTPUT
-              echo "helm_path=ray.image.tag" >> $GITHUB_OUTPUT
+              echo "helm_path=ray-cluster.image.tag" >> $GITHUB_OUTPUT
               ;;
             "console")
               echo "repository=console" >> $GITHUB_OUTPUT

--- a/Makefile.helper
+++ b/Makefile.helper
@@ -32,17 +32,10 @@ define HELM
 	@helm install ${HELM_RELEASE_NAME} charts/core \
 		--namespace ${HELM_NAMESPACE} --create-namespace \
 		--set edition=$(if $(filter true,$(1)),k8s-ce:test,k8s-ce) \
-		--set apiGateway.image.tag=${API_GATEWAY_VERSION} \
-		--set mgmtBackend.image.tag=${MGMT_BACKEND_VERSION} \
 		--set mgmtBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-		--set artifactBackend.image.tag=${ARTIFACT_BACKEND_VERSION} \
 		--set artifactBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-		--set pipelineBackend.image.tag=${PIPELINE_BACKEND_VERSION} \
 		--set pipelineBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
 		--set modelBackend.instillCoreHost=http://${INSTILL_CORE_HOST}:${API_GATEWAY_PORT} \
-		--set modelBackend.image.tag=${MODEL_BACKEND_VERSION} \
-		--set console.image.tag=${CONSOLE_VERSION} \
-		--set ray-cluster.image.tag=${RAY_RELEASE_TAG} \
 		$(if $(filter true,$(1)),--set ray-cluster.head.autoscaling.enableInTreeAutoscaling=false,) \
 		$(if $(filter true,$(1)),--set ray-cluster.head.resources.requests.cpu=0,) \
 		$(if $(filter true,$(1)),--set ray-cluster.head.resources.requests.memory=0,) \

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -119,7 +119,6 @@ expose:
       temporal:
     # Annotations on the LoadBalancer service
     annotations: {}
-
 # -- The external URL for Instill Core services. It is used to
 # populate the API endpoints showed on the console
 #
@@ -134,7 +133,6 @@ expose:
 # If Instill Core is deployed behind a proxy, set it as the URL of the proxy (without protocol and port)
 apiGatewayURL: http://localhost:8080
 consoleURL: http://localhost:3000
-
 # -- The internal TLS used for Core components secure communicating. In order to enable https
 # in each components tls cert files need to provided in advance.
 internalTLS:
@@ -195,7 +193,6 @@ internalTLS:
     crt: ""
     # Content of ray's TLS key file, only available when `certSource` is "manual"
     key: ""
-
 # -- The persistence is enabled by default and a default StorageClass
 # is needed in the k8s cluster to provision volumes dynamically.
 # Specify another StorageClass in the "storageClass" or set "existingClaim"
@@ -245,7 +242,6 @@ persistence:
       accessMode: ReadWriteOnce
       size: 100Gi
       annotations: {}
-
 # -- The usage collector configuration
 usage:
   usageidentifieruid:
@@ -253,7 +249,6 @@ usage:
   tlsenabled: true
   host: usage.instill-ai.com
   port: 443
-
 # -- The configuration of api-gateway
 apiGateway:
   # -- The image of api-gateway
@@ -320,7 +315,6 @@ apiGateway:
     spec:
       minAvailable:
       maxUnavailable:
-
 # -- The configuration of mgmt-backend
 mgmtBackend:
   # -- The image of mgmt-backend
@@ -399,7 +393,6 @@ mgmtBackend:
     clientKey:
     serverName:
     insecureSkipVerify:
-
 # -- The configuration of pipeline-backend
 pipelineBackend:
   # -- The image of pipeline-backend
@@ -488,7 +481,6 @@ pipelineBackend:
     password: minioadmin
     bucketname: instill-ai-pipeline
     secure: false
-
 # -- The configuration of pipeline-backend-worker
 pipelineBackendWorker:
   # -- Annotation for deployment
@@ -539,7 +531,6 @@ pipelineBackendWorker:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-
 # -- The configuration of model-backend
 modelBackend:
   # -- The image of model-backend
@@ -635,7 +626,6 @@ modelBackend:
     password: minioadmin
     bucketname: instill-ai-model
     secure: false
-
 # -- The configuration of artifact-backend
 artifactBackend:
   # -- The image of artifact-backend
@@ -713,7 +703,6 @@ artifactBackend:
   numberOfWorkers: 20
   blob:
     hostport: http://localhost:8080
-
 # -- The configuration of console
 console:
   # -- Enable console deployment or not
@@ -829,7 +818,6 @@ openfga:
     spec:
       minAvailable:
       maxUnavailable:
-
 # -- The configuration of registry
 registry:
   enabled: true
@@ -966,7 +954,6 @@ registry:
         idletimeout: 300s
       tls:
         enabled: false
-
 # -- The configuration of PostgreSQL
 database:
   # -- If external database is used, set "enabled" to false
@@ -1269,29 +1256,11 @@ ray-cluster:
           command:
             - "/bin/bash"
             - "-c"
-            - >
-              export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu; if [[ -n ${NVIDIA_VISIBLE_DEVICES} ]]; then
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+            - |
+              export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu;
+              if [[ -n ${NVIDIA_VISIBLE_DEVICES} ]]; then
                 sudo env PATH=$PATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH nvidia-ctk cdi generate --library-search-path=$LD_LIBRARY_PATH --output=/etc/cdi/nvidia.yaml;
               fi;
-
       preStop:
         exec:
           command: ["/bin/sh", "-c", "ray stop"]
@@ -1343,53 +1312,18 @@ ray-cluster:
           command:
             - "/bin/bash"
             - "-c"
-            - >
-              export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu; if [[ -n ${NVIDIA_VISIBLE_DEVICES} ]]; then
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+            - |
+              export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu;
+              if [[ -n ${NVIDIA_VISIBLE_DEVICES} ]]; then
                 sudo env PATH=$PATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH nvidia-ctk cdi generate --library-search-path=$LD_LIBRARY_PATH --output=/etc/cdi/nvidia.yaml;
-              fi; while true; do
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+              fi;
+              while true; do
                 ray health-check 2>/dev/null;
                 if [ "$?" = "0" ]; then
                     break;
                 fi;
                 sleep 1;
               done; serve start --http-host=0.0.0.0 --grpc-port 9000 --grpc-servicer-functions user_defined_pb2_grpc.add_UserDefinedServiceServicer_to_server
-
       preStop:
         exec:
           command: ["/bin/sh", "-c", "ray stop"]

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -259,7 +259,7 @@ apiGateway:
   # -- The image of api-gateway
   image:
     repository: instill/api-gateway
-    tag: 0.34.0
+    tag: 0768dba
     pullPolicy: IfNotPresent
   # -- Annotation for deployment
   annotations: {}
@@ -326,7 +326,7 @@ mgmtBackend:
   # -- The image of mgmt-backend
   image:
     repository: instill/mgmt-backend
-    tag: 0.23.0
+    tag: de4d6de
     pullPolicy: IfNotPresent
   # -- Annotation for deployment
   annotations: {}
@@ -405,7 +405,7 @@ pipelineBackend:
   # -- The image of pipeline-backend
   image:
     repository: instill/pipeline-backend
-    tag: 0.55.0
+    tag: 5a0c3d9
     pullPolicy: IfNotPresent
   # -- Annotation for deployment
   annotations: {}
@@ -545,7 +545,7 @@ modelBackend:
   # -- The image of model-backend
   image:
     repository: instill/model-backend
-    tag: 0.36.0
+    tag: 4da11d1
     pullPolicy: IfNotPresent
   # -- Annotation for deployment
   annotations: {}
@@ -641,7 +641,7 @@ artifactBackend:
   # -- The image of artifact-backend
   image:
     repository: instill/artifact-backend
-    tag: 0.26.0
+    tag: d202eff
     pullPolicy: IfNotPresent
   # -- Annotation for deployment
   annotations: {}
@@ -721,7 +721,7 @@ console:
   # -- The image of console
   image:
     repository: instill/console
-    tag: 0.68.1
+    tag: 0.68.3
     pullPolicy: IfNotPresent
   # -- The accessible endpoint for the api-gateway from the console server side
   serverApiGatewayURL:


### PR DESCRIPTION
Because

- we want to automatically update the image tags in Helm chart.

This commit

- updates the service image tag in Helm chart automatically.
- makes the image tag sync with the versions in .env file
