### PR TITLE
fix(helm): fix templates

### DIFF
--- a/charts/core/templates/mgmt-backend/configmap.yaml
+++ b/charts/core/templates/mgmt-backend/configmap.yaml
@@ -19,6 +19,7 @@ data:
         cert: /etc/instill-ai/core/ssl/mgmt/tls.crt
         key: /etc/instill-ai/core/ssl/mgmt/tls.key
       {{- end }}
+      defaultuseruid: {{ .Values.mgmtBackend.defaultUserUID }}
       instillcorehost: {{ .Values.mgmtBackend.instillCoreHost }}
     pipelinebackend:
       host: {{ include "core.pipelineBackend" . }}

--- a/charts/core/templates/redis/statefulset.yaml
+++ b/charts/core/templates/redis/statefulset.yaml
@@ -31,10 +31,10 @@ spec:
         runAsGroup: 1000
       {{- if .Values.redis.serviceAccountName }}
       serviceAccountName: {{ .Values.redis.serviceAccountName }}
-      {{- end -}}
-      {{- with .Values.imagePullSecrets }}
+      {{- end }}
       automountServiceAccountToken: {{ .Values.redis.automountServiceAccountToken | default false }}
       terminationGracePeriodSeconds: 120
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -316,6 +316,7 @@ mgmtBackend:
     worker: mgmt-backend-worker
   # -- The path of configuration file for mgmt-backend
   configPath: /mgmt-backend/config/config.yaml
+  defaultUserUID:
   instillCoreHost:
   # -- Set the service account to be used, default if left empty
   serviceAccountName: ""
@@ -1073,7 +1074,7 @@ openfga:
             value: "password"
 # -- The configuration of OpenTelemetry Collector
 opentelemetry-collector:
-  enabled: true
+  enabled: false
   mode: deployment
   image:
     repository: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib"


### PR DESCRIPTION
This commit

- fixes the chart template syntax error in the Redis manifest.
