### PR TITLE
chore(helm): use api-key for Temporal auth

### DIFF
--- a/charts/core/templates/mgmt-backend/configmap.yaml
+++ b/charts/core/templates/mgmt-backend/configmap.yaml
@@ -71,9 +71,6 @@ data:
     temporal:
       hostport: {{ default (printf "%s:%s" (include "temporal.host" .) (include "temporal.frontend.grpcPort" .)) .Values.mgmtBackend.temporal.hostPort }}
       namespace: {{ default "instill-core" .Values.mgmtBackend.temporal.namespace }}
-      serverrootca: {{ default "" .Values.mgmtBackend.temporal.serverRootCA }}
-      clientcert: {{ default "" .Values.mgmtBackend.temporal.clientCert }}
-      clientkey: {{ default "" .Values.mgmtBackend.temporal.clientKey }}
-      serverName: {{ default "" .Values.mgmtBackend.temporal.serverName }}
+      apikey: {{ default "" .Values.mgmtBackend.temporal.apiKey }}
       insecureskipverify: {{ default "true" .Values.mgmtBackend.temporal.insecureSkipVerify }}
       metricsport: {{ include "temporal.frontend.metricsPort" . }}

--- a/charts/core/templates/model-backend/configmap.yaml
+++ b/charts/core/templates/model-backend/configmap.yaml
@@ -84,10 +84,7 @@ data:
       hostport: {{ default (printf "%s:%s" (include "temporal.host" .) (include "temporal.frontend.grpcPort" .)) .Values.modelBackend.temporal.hostPort }}
       namespace: {{ default "instill-core" .Values.modelBackend.temporal.namespace }}
       retention: {{ default "1d" .Values.modelBackend.temporal.retention }}
-      serverrootca: {{ default "" .Values.modelBackend.temporal.serverRootCA }}
-      clientcert: {{ default "" .Values.modelBackend.temporal.clientCert }}
-      clientkey: {{ default "" .Values.modelBackend.temporal.clientKey }}
-      serverName: {{ default "" .Values.modelBackend.temporal.serverName }}
+      apikey: {{ default "" .Values.modelBackend.temporal.apiKey }}
       insecureskipverify: {{ default "true" .Values.modelBackend.temporal.insecureSkipVerify }}
       metricsport: {{ include "temporal.frontend.metricsPort" . }}
     initmodel:

--- a/charts/core/templates/pipeline-backend/configmap.yaml
+++ b/charts/core/templates/pipeline-backend/configmap.yaml
@@ -87,10 +87,7 @@ data:
     temporal:
       hostport: {{ default (printf "%s:%s" (include "temporal.host" .) (include "temporal.frontend.grpcPort" .)) .Values.pipelineBackend.temporal.hostPort }}
       namespace: {{ default "instill-core" .Values.pipelineBackend.temporal.namespace }}
-      servername: {{ default "" .Values.pipelineBackend.temporal.serverName }}
-      serverrootca: {{ default "" .Values.pipelineBackend.temporal.serverRootCA }}
-      clientcert: {{ default "" .Values.pipelineBackend.temporal.clientCert }}
-      clientkey: {{ default "" .Values.pipelineBackend.temporal.clientKey }}
+      apikey: {{ default "" .Values.pipelineBackend.temporal.apiKey }}
       insecureskipverify: {{ default "true" .Values.pipelineBackend.temporal.insecureSkipVerify }}
       metricsport: 9090
     otelcollector:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -373,10 +373,7 @@ mgmtBackend:
   temporal:
     hostPort:
     namespace:
-    serverRootCA:
-    clientCert:
-    clientKey:
-    serverName:
+    apiKey:
     insecureSkipVerify:
 # -- The configuration of pipeline-backend
 pipelineBackend:
@@ -405,10 +402,7 @@ pipelineBackend:
   temporal:
     hostPort:
     namespace:
-    serverName:
-    serverRootCA:
-    clientCert:
-    clientKey:
+    apiKey:
     insecureSkipVerify:
   # -- Set the service account to be used, default if left empty
   serviceAccountName: ""
@@ -542,10 +536,7 @@ modelBackend:
     hostPort:
     namespace:
     retention:
-    serverRootCA:
-    clientCert:
-    clientKey:
-    serverName:
+    apiKey:
     insecureSkipVerify:
     workflow:
       maxWorkflowTimeout: 3600 # in seconds


### PR DESCRIPTION
Because

- we want to use API key authentication for Temporal to simplify deployment.

This commit

- uses API key authentication for Temporal