### PR TITLE
fix(helm): remove temporal-admin-tools from api-gateway deployment

### DIFF
--- a/charts/core/templates/api-gateway/deployment.yaml
+++ b/charts/core/templates/api-gateway/deployment.yaml
@@ -70,18 +70,6 @@ spec:
               value: "{{ include "core.pipelineBackend" . }}"
             - name: PIPELINE_BACKEND_PORT
               value: "{{ include "core.pipelineBackend.publicPort" . }}"
-        - name: temporal-admin-tools
-          securityContext:
-            runAsUser: 0
-          image: temporalio/admin-tools:1.28
-          imagePullPolicy: IfNotPresent
-          command: ["/bin/bash", "-c"]
-          args:
-            - >
-              until tctl cluster health 2>&1 > /dev/null; do echo waiting for Temporal; sleep 2; done
-          env:
-            - name: TEMPORAL_CLI_ADDRESS
-              value: "{{ include "temporal.host" . }}:{{ include "temporal.frontend.grpcPort" . }}"
         {{- with .Values.apiGateway.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
This commit

- removes temporal-admin-tools from api-gateway deployment
