### PR TITLE
chore(helm): increase api-gateway health check delay

### DIFF
--- a/charts/core/templates/api-gateway/deployment.yaml
+++ b/charts/core/templates/api-gateway/deployment.yaml
@@ -83,14 +83,14 @@ spec:
               scheme: {{ upper (ternary "https" "http" .Values.apiGateway.tls.enabled) }}
               port: {{ ternary "https" "http" .Values.apiGateway.tls.enabled }}
             periodSeconds: 5
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
           livenessProbe:
             httpGet:
               path: /__health
               scheme: {{ upper (ternary "https" "http" .Values.apiGateway.tls.enabled) }}
               port: {{ ternary "https" "http" .Values.apiGateway.tls.enabled }}
             periodSeconds: 5
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             timeoutSeconds: 5
           {{- if .Values.apiGateway.resources }}
           resources:


### PR DESCRIPTION
Because

- there are more endpoints to be initialized

This commit

- increases the API gateway health check delay