### PR TITLE
ci(compose): replace wget with curl for all service health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget -qO- --no-verbose http://${API_GATEWAY_HOST}:${API_GATEWAY_PORT}/__health",
+          "curl -f -s http://${API_GATEWAY_HOST}:${API_GATEWAY_PORT}/__health",
         ]
       interval: 5s
       timeout: 3s
@@ -105,7 +105,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget -qO- --no-verbose http://${PIPELINE_BACKEND_HOST}:${PIPELINE_BACKEND_PUBLICPORT}/v1beta/health/pipeline",
+          "curl -f -s http://${PIPELINE_BACKEND_HOST}:${PIPELINE_BACKEND_PUBLICPORT}/v1beta/health/pipeline",
         ]
       interval: 5s
       timeout: 3s
@@ -198,7 +198,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget -qO- --no-verbose http://${ARTIFACT_BACKEND_HOST}:${ARTIFACT_BACKEND_PUBLICPORT}/v1alpha/health/artifact",
+          "curl -f -s http://${ARTIFACT_BACKEND_HOST}:${ARTIFACT_BACKEND_PUBLICPORT}/v1alpha/health/artifact",
         ]
       interval: 5s
       timeout: 3s
@@ -252,7 +252,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget -qO- --no-verbose http://${MODEL_BACKEND_HOST}:${MODEL_BACKEND_PUBLICPORT}/v1alpha/health/model",
+          "curl -f -s http://${MODEL_BACKEND_HOST}:${MODEL_BACKEND_PUBLICPORT}/v1alpha/health/model",
         ]
       interval: 5s
       timeout: 3s
@@ -343,7 +343,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget -qO- --no-verbose http://${MGMT_BACKEND_HOST}:${MGMT_BACKEND_PUBLICPORT}/v1beta/health/mgmt",
+          "curl -f -s http://${MGMT_BACKEND_HOST}:${MGMT_BACKEND_PUBLICPORT}/v1beta/health/mgmt",
         ]
       interval: 5s
       timeout: 3s


### PR DESCRIPTION
This commit

- adopts the common binary `curl` for health check among services.
