### PR TITLE
chore(registry): replace the docker image for kubectl use

### DIFF
--- a/charts/core/templates/registry/maintenance.yaml
+++ b/charts/core/templates/registry/maintenance.yaml
@@ -54,7 +54,7 @@ spec:
           serviceAccountName: {{ include "core.registry" . }}-maintenance
           containers:
             - name: kubectl
-              image: bitnami/kubectl
+              image: bitnamisecure/kubectl:latest
               command: ["/bin/bash", "-c"]
               args:
                 - |


### PR DESCRIPTION
Because

- We have to use bitnamisecure/kubectl rather than bitnami/kubectl docker image

This commit

- replace the docker image for kubectl use