### PR TITLE
ci(compose): disable gRPC proxy rate limiting

### DIFF
--- a/configs/compose/milvus/user.yaml
+++ b/configs/compose/milvus/user.yaml
@@ -1,1 +1,12 @@
 # Extra config to override default milvus.yaml
+
+# Disable gRPC proxy rate limiting middleware
+proxy:
+  grpc:
+    serverMaxRecvSize: 268435456 # 256MB
+    serverMaxSendSize: 268435456 # 256MB
+    clientMaxRecvSize: 268435456 # 256MB
+    clientMaxSendSize: 268435456 # 256MB
+  # Disable rate limiting at proxy level
+  rateLimiter:
+    enabled: false


### PR DESCRIPTION
Because

- The default rate limit for gRPC proxy is 0.1 RPS which is too strict.

This commit

- Disables rate limiting and set gRPC client and server max recv/send size.
