### PR TITLE
Security: Missing bounds checks on batch size can cause memory/CPU exhaustion

### DIFF
--- a/integration-test/models/dummy-chat/model.py
+++ b/integration-test/models/dummy-chat/model.py
@@ -6,6 +6,9 @@ from instill.helpers import (
 )
 
 
+MAX_BATCH_SIZE = 128
+
+
 @instill_deployment
 class Chat:
     def __init__(self):
@@ -15,6 +18,8 @@ class Chat:
         inputs = await parse_task_chat_to_chat_input(request=request)
 
         input_len = len(inputs)
+        if input_len > MAX_BATCH_SIZE:
+            raise ValueError(f"batch size exceeds maximum allowed: {MAX_BATCH_SIZE}")
 
         finish_reasons = [["length"] for _ in range(input_len)]
         indexes = [list(range(input_len))]


### PR DESCRIPTION
## Problem

Multiple handlers derive `input_len = len(inputs)` (or vision inputs) and allocate response lists directly from that size without limits. Large crafted requests can trigger oversized allocations and excessive compute, causing denial of service.

**Severity**: `medium`
**File**: `integration-test/models/dummy-chat/model.py`

## Solution

Validate and cap maximum batch size before processing (e.g., reject or truncate requests above a configured threshold) and add global request size limits.

## Changes

- `integration-test/models/dummy-chat/model.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple bounds check that rejects oversized chat batches before allocating per-item response structures. Main impact is a new `ValueError` for requests over the limit, which could affect any callers relying on unbounded batch sizes.
> 
> **Overview**
> Adds a **maximum batch size guard** to `integration-test/models/dummy-chat/model.py` by introducing `MAX_BATCH_SIZE = 128` and rejecting requests where `len(inputs)` exceeds this limit.
> 
> This prevents oversized batch requests from triggering large list allocations and excessive compute; oversized requests now fail fast with a `ValueError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a616489ba03bd421dc9fed3fec0a012c0cc2bbb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->