### PR TITLE
fix(helm): add missing openfga cache config to artifact-backend configmap

### DIFF
--- a/charts/core/templates/artifact-backend/configmap.yaml
+++ b/charts/core/templates/artifact-backend/configmap.yaml
@@ -61,8 +61,8 @@ data:
       host: {{ include "core.openfga" . }}
       port: 8081
       cache:
-        enabled: {{ default true .Values.openfga.cache.enabled }}
-        ttl: {{ default 60 .Values.openfga.cache.ttl }}
+        enabled: {{ if .Values.artifactBackendOpenfgaCache }}{{ default true .Values.artifactBackendOpenfgaCache.enabled }}{{ else }}true{{ end }}
+        ttl: {{ if .Values.artifactBackendOpenfgaCache }}{{ default 60 .Values.artifactBackendOpenfgaCache.ttl }}{{ else }}60{{ end }}
     temporal:
       hostport: {{ default (printf "%s:%s" (include "temporal.host" .) (include "temporal.frontend.grpcPort" .)) .Values.artifactBackend.temporal.hostPort }}
       namespace: {{ default "instill-core" .Values.artifactBackend.temporal.namespace }}

--- a/charts/core/templates/artifact-backend/configmap.yaml
+++ b/charts/core/templates/artifact-backend/configmap.yaml
@@ -60,6 +60,9 @@ data:
     openfga:
       host: {{ include "core.openfga" . }}
       port: 8081
+      cache:
+        enabled: {{ default true .Values.openfga.cache.enabled }}
+        ttl: {{ default 60 .Values.openfga.cache.ttl }}
     temporal:
       hostport: {{ default (printf "%s:%s" (include "temporal.host" .) (include "temporal.frontend.grpcPort" .)) .Values.artifactBackend.temporal.hostPort }}
       namespace: {{ default "instill-core" .Values.artifactBackend.temporal.namespace }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1039,6 +1039,10 @@ influxdb2:
 # -- The configuration of OpenFGA
 openfga:
   enabled: true
+  # -- Permission cache configuration (Redis-backed, covers CheckPermission and ListPermissions)
+  cache:
+    enabled: true
+    ttl: 60
   # -- The image of OpenFGA
   image:
     pullPolicy: IfNotPresent

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1036,13 +1036,14 @@ influxdb2:
 # ------------------------------------------------------------
 # The configuration of dependent Helm charts
 # ------------------------------------------------------------
+# -- OpenFGA permission cache for artifact-backend (Redis-backed).
+# Placed at top level to avoid OpenFGA subchart schema conflicts.
+artifactBackendOpenfgaCache:
+  enabled: true
+  ttl: 60
 # -- The configuration of OpenFGA
 openfga:
   enabled: true
-  # -- Permission cache configuration (Redis-backed, covers CheckPermission and ListPermissions)
-  cache:
-    enabled: true
-    ttl: 60
   # -- The image of OpenFGA
   image:
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Because

- The `x/acl` Redis cache for `ListPermissions` was never active in deployed environments because the `artifact-backend` configmap template did not include the `openfga.cache` block, causing `cacheEnabled` to default to `false`
- This results in every `ListFiles` call making a full `StreamedListObjects` RPC to OpenFGA (2-4s), triggering OpenFGA CPU spikes

## This commit

- Add `cache.enabled` and `cache.ttl` to artifact-backend configmap template
- Add default values (`enabled: true`, `ttl: 60`) in `values.yaml`

Made with [Cursor](https://cursor.com)